### PR TITLE
영화 조회 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,11 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'io.github.autoparams:autoparams:8.0.0'

--- a/src/main/java/com/kjh/ticketreserve/MovieSearchCondition.java
+++ b/src/main/java/com/kjh/ticketreserve/MovieSearchCondition.java
@@ -1,0 +1,6 @@
+package com.kjh.ticketreserve;
+
+import java.time.LocalDateTime;
+
+public record MovieSearchCondition(String title, LocalDateTime screeningDate) {
+}

--- a/src/main/java/com/kjh/ticketreserve/PageResponse.java
+++ b/src/main/java/com/kjh/ticketreserve/PageResponse.java
@@ -1,0 +1,16 @@
+package com.kjh.ticketreserve;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.function.Function;
+
+public record PageResponse<T>(int totalPages, long totalElements, int numberOfElements, List<T> content) {
+
+    public <S> PageResponse(Page<S> page, Function<S, T> mapper) {
+        this(page.getTotalPages(),
+            page.getTotalElements(),
+            page.getNumberOfElements(),
+            page.getContent().stream().map(mapper).toList());
+    }
+}

--- a/src/main/java/com/kjh/ticketreserve/controller/MovieController.java
+++ b/src/main/java/com/kjh/ticketreserve/controller/MovieController.java
@@ -1,13 +1,14 @@
 package com.kjh.ticketreserve.controller;
 
-import com.kjh.ticketreserve.MovieRequest;
-import com.kjh.ticketreserve.MovieResponse;
-import com.kjh.ticketreserve.exception.NotFoundException;
+import com.kjh.ticketreserve.*;
 import com.kjh.ticketreserve.jpa.MovieRepository;
 import com.kjh.ticketreserve.model.Movie;
 import com.kjh.ticketreserve.service.MovieService;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
 
 @RestController
 public class MovieController {
@@ -39,7 +40,7 @@ public class MovieController {
 
     @GetMapping("/admin/movies/{id}")
     public ResponseEntity<MovieResponse> getMovie(@PathVariable("id") long id) {
-        Movie movie = movieRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND::get);
+        Movie movie = movieService.getMovie(id);
         return ResponseEntity.status(200).body(new MovieResponse(
             movie.getId(),
             movie.getTitle(),
@@ -64,5 +65,17 @@ public class MovieController {
     public ResponseEntity<Object> deleteMovie(@PathVariable("id") long id) {
         movieService.deleteMovie(id);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/admin/movies")
+    public ResponseEntity<PageResponse<MovieResponse>> searchMovies(
+        @RequestParam int pageNumber,
+        @RequestParam int pageSize,
+        @RequestParam(required = false) String title,
+        @RequestParam(required = false) LocalDateTime screeningDate
+    ) {
+        Page<Movie> moviePage = movieService.searchMovies(pageNumber, pageSize, title, screeningDate);
+        return ResponseEntity.status(200).body(new PageResponse<>(moviePage,
+            m -> new MovieResponse(m.getId(), m.getTitle(), m.getStartDate(), m.getEndDate(), m.getPrice())));
     }
 }

--- a/src/main/java/com/kjh/ticketreserve/jpa/MovieCustomRepository.java
+++ b/src/main/java/com/kjh/ticketreserve/jpa/MovieCustomRepository.java
@@ -1,0 +1,11 @@
+package com.kjh.ticketreserve.jpa;
+
+import com.kjh.ticketreserve.MovieSearchCondition;
+import com.kjh.ticketreserve.model.Movie;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface MovieCustomRepository {
+
+    Page<Movie> findAllBySearchCondition(MovieSearchCondition searchCondition, Pageable pageable);
+}

--- a/src/main/java/com/kjh/ticketreserve/jpa/MovieCustomRepositoryImpl.java
+++ b/src/main/java/com/kjh/ticketreserve/jpa/MovieCustomRepositoryImpl.java
@@ -1,0 +1,45 @@
+package com.kjh.ticketreserve.jpa;
+
+import com.kjh.ticketreserve.MovieSearchCondition;
+import com.kjh.ticketreserve.model.Movie;
+import com.querydsl.core.types.dsl.Wildcard;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import static com.kjh.ticketreserve.jpa.QuerydslPredicateUtils.ifNullNone;
+import static com.kjh.ticketreserve.model.QMovie.movie;
+
+@RequiredArgsConstructor
+public class MovieCustomRepositoryImpl implements MovieCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Movie> findAllBySearchCondition(MovieSearchCondition searchCondition, Pageable pageable) {
+        JPAQuery<Movie> query = queryFactory
+            .select(movie)
+            .from(movie)
+            .where(
+                ifNullNone(movie.title::contains, searchCondition.title()),
+                ifNullNone(movie.startDate::loe, searchCondition.screeningDate()),
+                ifNullNone(movie.endDate::goe, searchCondition.screeningDate())
+            )
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize());
+
+        JPAQuery<Long> countQuery = queryFactory
+            .select(Wildcard.count)
+            .from(movie)
+            .where(
+                ifNullNone(movie.title::contains, searchCondition.title()),
+                ifNullNone(movie.startDate::loe, searchCondition.screeningDate()),
+                ifNullNone(movie.endDate::goe, searchCondition.screeningDate())
+            );
+
+        return new PageImpl<>(query.fetch(), pageable, countQuery.fetch().get(0));
+    }
+}

--- a/src/main/java/com/kjh/ticketreserve/jpa/MovieRepository.java
+++ b/src/main/java/com/kjh/ticketreserve/jpa/MovieRepository.java
@@ -3,5 +3,5 @@ package com.kjh.ticketreserve.jpa;
 import com.kjh.ticketreserve.model.Movie;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MovieRepository extends JpaRepository<Movie, Long> {
+public interface MovieRepository extends JpaRepository<Movie, Long>, MovieCustomRepository {
 }

--- a/src/main/java/com/kjh/ticketreserve/jpa/QuerydslConfig.java
+++ b/src/main/java/com/kjh/ticketreserve/jpa/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.kjh.ticketreserve.jpa;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/kjh/ticketreserve/jpa/QuerydslPredicateUtils.java
+++ b/src/main/java/com/kjh/ticketreserve/jpa/QuerydslPredicateUtils.java
@@ -1,0 +1,15 @@
+package com.kjh.ticketreserve.jpa;
+
+import com.querydsl.core.types.Predicate;
+
+import java.util.function.Function;
+
+public class QuerydslPredicateUtils {
+
+    public static <T> Predicate ifNullNone(Function<T, Predicate> expression, T value) {
+        if (value == null) {
+            return null;
+        }
+        return expression.apply(value);
+    }
+}

--- a/src/main/java/com/kjh/ticketreserve/jpa/QuerydslPredicateUtils.java
+++ b/src/main/java/com/kjh/ticketreserve/jpa/QuerydslPredicateUtils.java
@@ -1,10 +1,13 @@
 package com.kjh.ticketreserve.jpa;
 
 import com.querydsl.core.types.Predicate;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 import java.util.function.Function;
 
-public class QuerydslPredicateUtils {
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class QuerydslPredicateUtils {
 
     public static <T> Predicate ifNullNone(Function<T, Predicate> expression, T value) {
         if (value == null) {

--- a/src/main/java/com/kjh/ticketreserve/service/MovieService.java
+++ b/src/main/java/com/kjh/ticketreserve/service/MovieService.java
@@ -1,11 +1,16 @@
 package com.kjh.ticketreserve.service;
 
 import com.kjh.ticketreserve.MovieRequest;
+import com.kjh.ticketreserve.MovieSearchCondition;
 import com.kjh.ticketreserve.exception.NotFoundException;
 import com.kjh.ticketreserve.jpa.MovieRepository;
 import com.kjh.ticketreserve.model.Movie;
-import jakarta.transaction.Transactional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
 
 @Service
 public class MovieService {
@@ -14,6 +19,11 @@ public class MovieService {
 
     public MovieService(MovieRepository movieRepository) {
         this.movieRepository = movieRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public Movie getMovie(long id) {
+        return movieRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND::get);
     }
 
     @Transactional
@@ -30,5 +40,11 @@ public class MovieService {
     public void deleteMovie(long id) {
         Movie movie = movieRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND::get);
         movieRepository.delete(movie);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Movie> searchMovies(int pageNumber, int pageSize, String title, LocalDateTime screeningDate) {
+        MovieSearchCondition searchCondition = new MovieSearchCondition(title, screeningDate);
+        return movieRepository.findAllBySearchCondition(searchCondition, PageRequest.of(pageNumber, pageSize));
     }
 }

--- a/src/test/java/com/kjh/ticketreserve/TestLanguage.java
+++ b/src/test/java/com/kjh/ticketreserve/TestLanguage.java
@@ -57,6 +57,13 @@ public class TestLanguage {
         return client.exchange(path, HttpMethod.GET, new HttpEntity<>(getHttpHeaders(accessToken)), type);
     }
 
+    public static <T> ResponseEntity<T> getWithToken(TestRestTemplate client,
+                                                     String accessToken,
+                                                     String path,
+                                                     ParameterizedTypeReference<T> type) {
+        return client.exchange(path, HttpMethod.GET, new HttpEntity<>(getHttpHeaders(accessToken)), type);
+    }
+
     public static <Request, Response> ResponseEntity<Response> postWithToken(
         TestRestTemplate client,
         String accessToken,

--- a/src/test/java/com/kjh/ticketreserve/movie/GetTests.java
+++ b/src/test/java/com/kjh/ticketreserve/movie/GetTests.java
@@ -1,15 +1,16 @@
 package com.kjh.ticketreserve.movie;
 
-import com.kjh.ticketreserve.AutoDomainSource;
-import com.kjh.ticketreserve.Credentials;
-import com.kjh.ticketreserve.MovieRequest;
-import com.kjh.ticketreserve.MovieResponse;
+import com.kjh.ticketreserve.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 import static com.kjh.ticketreserve.TestLanguage.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -25,16 +26,19 @@ public class GetTests {
         MovieRequest movieRequest,
         @Autowired TestRestTemplate client
     ) {
+        // Arrange
         signup(client, credentials);
         String accessToken = signin(client, credentials);
         long id = createMovie(client, accessToken, movieRequest);
 
+        // Act
         ResponseEntity<MovieResponse> response = getWithToken(
             client,
             accessToken,
             "/admin/movies/" + id,
             MovieResponse.class);
 
+        // Assert
         assertThat(response.getStatusCode().value()).isEqualTo(200);
         MovieResponse body = response.getBody();
         assertThat(body).isNotNull();
@@ -43,5 +47,109 @@ public class GetTests {
         assertThat(body.startDate()).isEqualToIgnoringNanos(movieRequest.startDate());
         assertThat(body.endDate()).isEqualToIgnoringNanos(movieRequest.endDate());
         assertThat(body.price()).isEqualTo(movieRequest.price());
+    }
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 영화를_검색하면_영화_리스트를_반환한다(
+        Credentials credentials,
+        List<MovieRequest> movieRequests,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        for (MovieRequest movieRequest : movieRequests) {
+            createMovie(client, accessToken, movieRequest);
+        }
+
+        // Act
+        ResponseEntity<PageResponse<MovieResponse>> response = getWithToken(client,
+            accessToken,
+            "/admin/movies?pageNumber=0&pageSize=" + movieRequests.size(),
+            new ParameterizedTypeReference<>() {
+            });
+
+        // Assert
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().content().size()).isEqualTo(movieRequests.size());
+    }
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 영화_제목을_사용해_검색하면_조건에_맞는_영화_리스트를_반환한다(
+        Credentials credentials,
+        List<MovieRequest> movieRequests,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        for (MovieRequest movieRequest : movieRequests) {
+            createMovie(client, accessToken, movieRequest);
+        }
+
+        // Act
+        MovieRequest movieToFind = movieRequests.get(0);
+        ResponseEntity<PageResponse<MovieResponse>> response = getWithToken(client,
+            accessToken,
+            "/admin/movies?pageNumber=0&pageSize=" + movieRequests.size() + "&title=" + movieToFind.title(),
+            new ParameterizedTypeReference<>() {
+            });
+
+        // Assert
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().content().size()).isEqualTo(1);
+        MovieResponse found = response.getBody().content().get(0);
+        assertThat(found.title()).isEqualTo(movieToFind.title());
+        assertThat(found.startDate()).isEqualToIgnoringNanos(found.startDate());
+        assertThat(found.endDate()).isEqualToIgnoringNanos(found.endDate());
+        assertThat(found.price()).isEqualTo(movieToFind.price());
+    }
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 영화_상영일을_사용해_검색하면_조건에_맞는_영화_리스트를_반환한다(
+        Credentials credentials,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        List<MovieRequest> movieRequests = List.of(
+            new MovieRequest("movie1",
+                LocalDateTime.of(2024, 5, 1, 0, 0),
+                LocalDateTime.of(2024, 5, 10, 23, 59),
+                10000),
+            new MovieRequest("movie2",
+                LocalDateTime.of(2024, 5, 2, 0, 0),
+                LocalDateTime.of(2024, 5, 10, 23, 59),
+                10000),
+            new MovieRequest("movie3",
+                LocalDateTime.of(2024, 4, 1, 0, 0),
+                LocalDateTime.of(2024, 4, 30, 23, 59),
+                10000)
+        );
+        for (MovieRequest movieRequest : movieRequests) {
+            createMovie(client, accessToken, movieRequest);
+        }
+
+        // Act
+        MovieRequest movieToFind = movieRequests.get(0);
+        ResponseEntity<PageResponse<MovieResponse>> response = getWithToken(client,
+            accessToken,
+            "/admin/movies?pageNumber=0&pageSize=" + movieRequests.size() + "&screeningDate=" + movieToFind.startDate(),
+            new ParameterizedTypeReference<>() {
+            });
+
+        // Assert
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().content().size()).isEqualTo(1);
+        MovieResponse found = response.getBody().content().get(0);
+        assertThat(found.title()).isEqualTo(movieToFind.title());
+        assertThat(found.startDate()).isEqualToIgnoringNanos(found.startDate());
+        assertThat(found.endDate()).isEqualToIgnoringNanos(found.endDate());
+        assertThat(found.price()).isEqualTo(movieToFind.price());
     }
 }


### PR DESCRIPTION
- 아이디를 사용한 영화 단건 조회 기능 
  - GET `/admin/movies/{id}`
- 검색 조건을 사용한 영화 목록 조회 기능 (페이징 처리) 
  - GET `/admin/movies?pageNumber={pageNumber}&pageSize={pageSize}&title={title}&screeningDate={screeningDate}`
  - 검색 조건
    - title(제목): 제목에 검색어가 포함된 영화 조회 (like 검색)
    - screeningDate(상영일): 해당 일자에 상영 중인 영화 조회

Resolves #4