### PR TITLE
영화관 등록/수정/삭제/조회 기능 추가

### DIFF
--- a/src/main/java/com/kjh/ticketreserve/TheaterRequest.java
+++ b/src/main/java/com/kjh/ticketreserve/TheaterRequest.java
@@ -1,0 +1,4 @@
+package com.kjh.ticketreserve;
+
+public record TheaterRequest(String name, String address) {
+}

--- a/src/main/java/com/kjh/ticketreserve/TheaterResponse.java
+++ b/src/main/java/com/kjh/ticketreserve/TheaterResponse.java
@@ -1,0 +1,4 @@
+package com.kjh.ticketreserve;
+
+public record TheaterResponse(long id, String name, String address) {
+}

--- a/src/main/java/com/kjh/ticketreserve/TheaterSearchCondition.java
+++ b/src/main/java/com/kjh/ticketreserve/TheaterSearchCondition.java
@@ -1,0 +1,4 @@
+package com.kjh.ticketreserve;
+
+public record TheaterSearchCondition(String name, String address) {
+}

--- a/src/main/java/com/kjh/ticketreserve/controller/TheaterController.java
+++ b/src/main/java/com/kjh/ticketreserve/controller/TheaterController.java
@@ -48,4 +48,10 @@ public class TheaterController {
             theater.getName(),
             theater.getAddress()));
     }
+
+    @DeleteMapping("/admin/theaters/{id}")
+    public ResponseEntity<TheaterResponse> deleteTheater(@PathVariable("id") Long id) {
+        theaterService.deleteTheater(id);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/kjh/ticketreserve/controller/TheaterController.java
+++ b/src/main/java/com/kjh/ticketreserve/controller/TheaterController.java
@@ -38,4 +38,14 @@ public class TheaterController {
             theater.getName(),
             theater.getAddress()));
     }
+
+    @PutMapping("/admin/theaters/{id}")
+    public ResponseEntity<TheaterResponse> updateTheater(@PathVariable("id") Long id,
+                                                         @RequestBody TheaterRequest theaterRequest) {
+        Theater theater = theaterService.updateTheater(id, theaterRequest);
+        return ResponseEntity.status(200).body(new TheaterResponse(
+            theater.getId(),
+            theater.getName(),
+            theater.getAddress()));
+    }
 }

--- a/src/main/java/com/kjh/ticketreserve/controller/TheaterController.java
+++ b/src/main/java/com/kjh/ticketreserve/controller/TheaterController.java
@@ -1,0 +1,41 @@
+package com.kjh.ticketreserve.controller;
+
+import com.kjh.ticketreserve.TheaterRequest;
+import com.kjh.ticketreserve.TheaterResponse;
+import com.kjh.ticketreserve.model.Theater;
+import com.kjh.ticketreserve.service.TheaterService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class TheaterController {
+
+    private final TheaterService theaterService;
+
+    public TheaterController(TheaterService theaterService) {
+        this.theaterService = theaterService;
+    }
+
+    @PostMapping("/admin/theaters")
+    public ResponseEntity<TheaterResponse> createTheater(@RequestBody TheaterRequest theaterRequest) {
+        Theater theater = new Theater();
+        theater.setName(theaterRequest.name());
+        theater.setAddress(theaterRequest.address());
+        theaterService.createTheater(theater);
+
+        return ResponseEntity.status(201).body(new TheaterResponse(
+            theater.getId(),
+            theater.getName(),
+            theater.getAddress()
+        ));
+    }
+
+    @GetMapping("/theaters/{id}")
+    public ResponseEntity<TheaterResponse> getTheater(@PathVariable Long id) {
+        Theater theater = theaterService.getTheater(id);
+        return ResponseEntity.status(200).body(new TheaterResponse(
+            theater.getId(),
+            theater.getName(),
+            theater.getAddress()));
+    }
+}

--- a/src/main/java/com/kjh/ticketreserve/controller/TheaterController.java
+++ b/src/main/java/com/kjh/ticketreserve/controller/TheaterController.java
@@ -1,9 +1,11 @@
 package com.kjh.ticketreserve.controller;
 
+import com.kjh.ticketreserve.PageResponse;
 import com.kjh.ticketreserve.TheaterRequest;
 import com.kjh.ticketreserve.TheaterResponse;
 import com.kjh.ticketreserve.model.Theater;
 import com.kjh.ticketreserve.service.TheaterService;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -53,5 +55,17 @@ public class TheaterController {
     public ResponseEntity<TheaterResponse> deleteTheater(@PathVariable("id") Long id) {
         theaterService.deleteTheater(id);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/theaters")
+    public ResponseEntity<PageResponse<TheaterResponse>> searchTheaters(
+        @RequestParam int pageNumber,
+        @RequestParam int pageSize,
+        @RequestParam(required = false) String name,
+        @RequestParam(required = false) String address
+    ) {
+        Page<Theater> theaterPage = theaterService.searchTheaters(pageNumber, pageSize, name, address);
+        return ResponseEntity.status(200).body(new PageResponse<>(theaterPage,
+            t -> new TheaterResponse(t.getId(), t.getName(), t.getAddress())));
     }
 }

--- a/src/main/java/com/kjh/ticketreserve/jpa/TheaterCustomRepository.java
+++ b/src/main/java/com/kjh/ticketreserve/jpa/TheaterCustomRepository.java
@@ -1,0 +1,11 @@
+package com.kjh.ticketreserve.jpa;
+
+import com.kjh.ticketreserve.TheaterSearchCondition;
+import com.kjh.ticketreserve.model.Theater;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface TheaterCustomRepository {
+
+    Page<Theater> findAllBySearchCondition(TheaterSearchCondition searchCondition, Pageable pageable);
+}

--- a/src/main/java/com/kjh/ticketreserve/jpa/TheaterCustomRepositoryImpl.java
+++ b/src/main/java/com/kjh/ticketreserve/jpa/TheaterCustomRepositoryImpl.java
@@ -1,0 +1,43 @@
+package com.kjh.ticketreserve.jpa;
+
+import com.kjh.ticketreserve.TheaterSearchCondition;
+import com.kjh.ticketreserve.model.Theater;
+import com.querydsl.core.types.dsl.Wildcard;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import static com.kjh.ticketreserve.jpa.QuerydslPredicateUtils.ifNullNone;
+import static com.kjh.ticketreserve.model.QTheater.theater;
+
+@RequiredArgsConstructor
+public class TheaterCustomRepositoryImpl implements TheaterCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Theater> findAllBySearchCondition(TheaterSearchCondition searchCondition, Pageable pageable) {
+        JPAQuery<Theater> query = queryFactory
+            .select(theater)
+            .from(theater)
+            .where(
+                ifNullNone(theater.name::contains, searchCondition.name()),
+                ifNullNone(theater.address::contains, searchCondition.address())
+            )
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize());
+
+        JPAQuery<Long> countQuery = queryFactory
+            .select(Wildcard.count)
+            .from(theater)
+            .where(
+                ifNullNone(theater.name::contains, searchCondition.name()),
+                ifNullNone(theater.address::contains, searchCondition.address())
+            );
+
+        return new PageImpl<>(query.fetch(), pageable, countQuery.fetch().get(0));
+    }
+}

--- a/src/main/java/com/kjh/ticketreserve/jpa/TheaterRepository.java
+++ b/src/main/java/com/kjh/ticketreserve/jpa/TheaterRepository.java
@@ -1,0 +1,7 @@
+package com.kjh.ticketreserve.jpa;
+
+import com.kjh.ticketreserve.model.Theater;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TheaterRepository extends JpaRepository<Theater, Long> {
+}

--- a/src/main/java/com/kjh/ticketreserve/jpa/TheaterRepository.java
+++ b/src/main/java/com/kjh/ticketreserve/jpa/TheaterRepository.java
@@ -3,5 +3,5 @@ package com.kjh.ticketreserve.jpa;
 import com.kjh.ticketreserve.model.Theater;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TheaterRepository extends JpaRepository<Theater, Long> {
+public interface TheaterRepository extends JpaRepository<Theater, Long>, TheaterCustomRepository {
 }

--- a/src/main/java/com/kjh/ticketreserve/model/Theater.java
+++ b/src/main/java/com/kjh/ticketreserve/model/Theater.java
@@ -1,0 +1,21 @@
+package com.kjh.ticketreserve.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class Theater {
+
+    @Id
+    @GeneratedValue
+    Long id;
+    private String name;
+    private String address;
+}

--- a/src/main/java/com/kjh/ticketreserve/service/TheaterService.java
+++ b/src/main/java/com/kjh/ticketreserve/service/TheaterService.java
@@ -1,9 +1,12 @@
 package com.kjh.ticketreserve.service;
 
 import com.kjh.ticketreserve.TheaterRequest;
+import com.kjh.ticketreserve.TheaterSearchCondition;
 import com.kjh.ticketreserve.exception.NotFoundException;
 import com.kjh.ticketreserve.jpa.TheaterRepository;
 import com.kjh.ticketreserve.model.Theater;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,5 +41,11 @@ public class TheaterService {
     public void deleteTheater(long id) {
         Theater theater = theaterRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND::get);
         theaterRepository.delete(theater);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Theater> searchTheaters(int pageNumber, int pageSize, String name, String address) {
+        TheaterSearchCondition searchCondition = new TheaterSearchCondition(name, address);
+        return theaterRepository.findAllBySearchCondition(searchCondition, PageRequest.of(pageNumber, pageSize));
     }
 }

--- a/src/main/java/com/kjh/ticketreserve/service/TheaterService.java
+++ b/src/main/java/com/kjh/ticketreserve/service/TheaterService.java
@@ -1,5 +1,6 @@
 package com.kjh.ticketreserve.service;
 
+import com.kjh.ticketreserve.TheaterRequest;
 import com.kjh.ticketreserve.exception.NotFoundException;
 import com.kjh.ticketreserve.jpa.TheaterRepository;
 import com.kjh.ticketreserve.model.Theater;
@@ -23,5 +24,13 @@ public class TheaterService {
     @Transactional(readOnly = true)
     public Theater getTheater(long id) {
         return theaterRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND::get);
+    }
+
+    @Transactional
+    public Theater updateTheater(long id, TheaterRequest theaterRequest) {
+        Theater theater = theaterRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND::get);
+        theater.setName(theaterRequest.name());
+        theater.setAddress(theaterRequest.address());
+        return theater;
     }
 }

--- a/src/main/java/com/kjh/ticketreserve/service/TheaterService.java
+++ b/src/main/java/com/kjh/ticketreserve/service/TheaterService.java
@@ -33,4 +33,10 @@ public class TheaterService {
         theater.setAddress(theaterRequest.address());
         return theater;
     }
+
+    @Transactional
+    public void deleteTheater(long id) {
+        Theater theater = theaterRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND::get);
+        theaterRepository.delete(theater);
+    }
 }

--- a/src/main/java/com/kjh/ticketreserve/service/TheaterService.java
+++ b/src/main/java/com/kjh/ticketreserve/service/TheaterService.java
@@ -1,0 +1,27 @@
+package com.kjh.ticketreserve.service;
+
+import com.kjh.ticketreserve.exception.NotFoundException;
+import com.kjh.ticketreserve.jpa.TheaterRepository;
+import com.kjh.ticketreserve.model.Theater;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class TheaterService {
+
+    private final TheaterRepository theaterRepository;
+
+    public TheaterService(TheaterRepository theaterRepository) {
+        this.theaterRepository = theaterRepository;
+    }
+
+    @Transactional
+    public void createTheater(Theater theater) {
+        theaterRepository.save(theater);
+    }
+
+    @Transactional(readOnly = true)
+    public Theater getTheater(long id) {
+        return theaterRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND::get);
+    }
+}

--- a/src/test/java/com/kjh/ticketreserve/TestLanguage.java
+++ b/src/test/java/com/kjh/ticketreserve/TestLanguage.java
@@ -127,4 +127,16 @@ public class TestLanguage {
 
         return response.getBody().id();
     }
+
+    @SuppressWarnings("DataFlowIssue")
+    public static long createTheater(TheaterRequest theaterRequest, TestRestTemplate client, String accessToken) {
+        ResponseEntity<TheaterResponse> response = postWithToken(client,
+            accessToken,
+            "/admin/theaters",
+            theaterRequest,
+            new ParameterizedTypeReference<>() {
+            });
+
+        return response.getBody().id();
+    }
 }

--- a/src/test/java/com/kjh/ticketreserve/TestLanguage.java
+++ b/src/test/java/com/kjh/ticketreserve/TestLanguage.java
@@ -129,7 +129,11 @@ public class TestLanguage {
     }
 
     @SuppressWarnings("DataFlowIssue")
-    public static long createTheater(TheaterRequest theaterRequest, TestRestTemplate client, String accessToken) {
+    public static long createTheater(
+        TestRestTemplate client,
+        String accessToken,
+        TheaterRequest theaterRequest) {
+
         ResponseEntity<TheaterResponse> response = postWithToken(client,
             accessToken,
             "/admin/theaters",

--- a/src/test/java/com/kjh/ticketreserve/theater/DeleteTests.java
+++ b/src/test/java/com/kjh/ticketreserve/theater/DeleteTests.java
@@ -1,0 +1,64 @@
+package com.kjh.ticketreserve.theater;
+
+import com.kjh.ticketreserve.AutoDomainSource;
+import com.kjh.ticketreserve.Credentials;
+import com.kjh.ticketreserve.TheaterRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.ResponseEntity;
+
+import static com.kjh.ticketreserve.TestLanguage.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("DELETE /admin/theaters")
+public class DeleteTests {
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 영화관_아이디를_사용해_영화관을_삭제하면_OK_상태코드를_반환한다(
+        Credentials credentials,
+        TheaterRequest theaterRequest,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        long id = createTheater(client, accessToken, theaterRequest);
+
+        // Act
+        ResponseEntity<Object> response = deleteWithToken(client,
+            accessToken,
+            "/admin/theaters/" + id,
+            Object.class);
+
+        // Assert
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+    }
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 존재하지_않는_영화관_아이디를_사용해_삭제하면_Not_Found_상태코드를_반환한다(
+        Credentials credentials,
+        TheaterRequest theaterRequest,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        long id = createTheater(client, accessToken, theaterRequest);
+        deleteWithToken(client, accessToken, "/admin/theaters/" + id, Void.class);
+
+        // Act
+        ResponseEntity<Object> response = deleteWithToken(client,
+            accessToken,
+            "/admin/theaters/" + id,
+            Object.class);
+
+        // Assert
+        assertThat(response.getStatusCode().value()).isEqualTo(404);
+    }
+}

--- a/src/test/java/com/kjh/ticketreserve/theater/GetTests.java
+++ b/src/test/java/com/kjh/ticketreserve/theater/GetTests.java
@@ -1,15 +1,15 @@
 package com.kjh.ticketreserve.theater;
 
-import com.kjh.ticketreserve.AutoDomainSource;
-import com.kjh.ticketreserve.Credentials;
-import com.kjh.ticketreserve.TheaterRequest;
-import com.kjh.ticketreserve.TheaterResponse;
+import com.kjh.ticketreserve.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.ResponseEntity;
+
+import java.util.List;
 
 import static com.kjh.ticketreserve.TestLanguage.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,5 +43,92 @@ public class GetTests {
         assertThat(body.id()).isEqualTo(id);
         assertThat(body.name()).isEqualTo(theaterRequest.name());
         assertThat(body.address()).isEqualTo(theaterRequest.address());
+    }
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 영화관을_검색하면_영화관_리스트를_반환한다(
+        Credentials credentials,
+        List<TheaterRequest> theaterRequests,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        for (TheaterRequest theaterRequest : theaterRequests) {
+            createTheater(client, accessToken, theaterRequest);
+        }
+
+        // Act
+        ResponseEntity<PageResponse<TheaterResponse>> response = getWithToken(client,
+            accessToken,
+            "/theaters?pageNumber=0&pageSize=" + theaterRequests.size(),
+            new ParameterizedTypeReference<>() {
+            });
+
+        // Assert
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().content().size()).isEqualTo(theaterRequests.size());
+    }
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 영화관_이름을_사용해_검색하면_조건에_맞는_영화관_리스트를_반환한다(
+        Credentials credentials,
+        List<TheaterRequest> theaterRequests,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        for (TheaterRequest theaterRequest : theaterRequests) {
+            createTheater(client, accessToken, theaterRequest);
+        }
+
+        // Act
+        TheaterRequest theaterToFind = theaterRequests.get(1);
+        ResponseEntity<PageResponse<TheaterResponse>> response = getWithToken(client,
+            accessToken,
+            "/theaters?pageNumber=0&pageSize=" + theaterRequests.size() + "&name=" + theaterToFind.name(),
+            new ParameterizedTypeReference<>() {
+            });
+
+        // Assert
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().content().size()).isEqualTo(1);
+        TheaterResponse found = response.getBody().content().get(0);
+        assertThat(found.name()).isEqualTo(theaterToFind.name());
+        assertThat(found.address()).isEqualTo(theaterToFind.address());
+    }
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 영화관_주소를_사용해_검색하면_조건에_맞는_영화관_리스트를_반환한다(
+        Credentials credentials,
+        List<TheaterRequest> theaterRequests,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        for (TheaterRequest theaterRequest : theaterRequests) {
+            createTheater(client, accessToken, theaterRequest);
+        }
+
+        // Act
+        TheaterRequest theaterToFind = theaterRequests.get(1);
+        ResponseEntity<PageResponse<TheaterResponse>> response = getWithToken(client,
+            accessToken,
+            "/theaters?pageNumber=0&pageSize=" + theaterRequests.size() + "&address=" + theaterToFind.address(),
+            new ParameterizedTypeReference<>() {
+            });
+
+        // Assert
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().content().size()).isEqualTo(1);
+        TheaterResponse found = response.getBody().content().get(0);
+        assertThat(found.name()).isEqualTo(theaterToFind.name());
+        assertThat(found.address()).isEqualTo(theaterToFind.address());
     }
 }

--- a/src/test/java/com/kjh/ticketreserve/theater/GetTests.java
+++ b/src/test/java/com/kjh/ticketreserve/theater/GetTests.java
@@ -28,7 +28,7 @@ public class GetTests {
         // Arrange
         signup(client, credentials);
         String accessToken = signin(client, credentials);
-        long id = createTheater(theaterRequest, client, accessToken);
+        long id = createTheater(client, accessToken, theaterRequest);
 
         // Act
         ResponseEntity<TheaterResponse> response = getWithToken(client,

--- a/src/test/java/com/kjh/ticketreserve/theater/GetTests.java
+++ b/src/test/java/com/kjh/ticketreserve/theater/GetTests.java
@@ -1,0 +1,47 @@
+package com.kjh.ticketreserve.theater;
+
+import com.kjh.ticketreserve.AutoDomainSource;
+import com.kjh.ticketreserve.Credentials;
+import com.kjh.ticketreserve.TheaterRequest;
+import com.kjh.ticketreserve.TheaterResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.ResponseEntity;
+
+import static com.kjh.ticketreserve.TestLanguage.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("GET /theaters")
+public class GetTests {
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 영화관_아이디를_사용해_조회하면_영화관_정보를_반환한다(
+        Credentials credentials,
+        TheaterRequest theaterRequest,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        long id = createTheater(theaterRequest, client, accessToken);
+
+        // Act
+        ResponseEntity<TheaterResponse> response = getWithToken(client,
+            accessToken,
+            "/theaters/" + id,
+            TheaterResponse.class);
+
+        // Assert
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        TheaterResponse body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.id()).isEqualTo(id);
+        assertThat(body.name()).isEqualTo(theaterRequest.name());
+        assertThat(body.address()).isEqualTo(theaterRequest.address());
+    }
+}

--- a/src/test/java/com/kjh/ticketreserve/theater/PostTests.java
+++ b/src/test/java/com/kjh/ticketreserve/theater/PostTests.java
@@ -1,0 +1,45 @@
+package com.kjh.ticketreserve.theater;
+
+import com.kjh.ticketreserve.AutoDomainSource;
+import com.kjh.ticketreserve.Credentials;
+import com.kjh.ticketreserve.TheaterRequest;
+import com.kjh.ticketreserve.TheaterResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.ResponseEntity;
+
+import static com.kjh.ticketreserve.TestLanguage.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("POST /admin/theaters")
+public class PostTests {
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 영화관을_등록하면_아이디를_반환한다(
+        Credentials credentials,
+        TheaterRequest theaterRequest,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+
+        // Act
+        ResponseEntity<TheaterResponse> response = postWithToken(client,
+            accessToken,
+            "/admin/theaters",
+            theaterRequest,
+            new ParameterizedTypeReference<>() {
+            });
+
+        // Assert
+        assertThat(response.getStatusCode().value()).isEqualTo(201);
+        assertThat(response.getBody()).hasFieldOrProperty("id");
+    }
+}

--- a/src/test/java/com/kjh/ticketreserve/theater/PutTests.java
+++ b/src/test/java/com/kjh/ticketreserve/theater/PutTests.java
@@ -1,0 +1,72 @@
+package com.kjh.ticketreserve.theater;
+
+import com.kjh.ticketreserve.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.ResponseEntity;
+
+import static com.kjh.ticketreserve.TestLanguage.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("PUT /admin/theaters")
+public class PutTests {
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 영화관_아이디를_사용해_영화관_정보를_수정하면_수정된_정보를_반환한다(
+        Credentials credentials,
+        TheaterRequest createTheaterRequest,
+        TheaterRequest updateTheaterRequest,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        long id = createTheater(client, accessToken, createTheaterRequest);
+
+        // Act
+        ResponseEntity<TheaterResponse> response = putWithToken(client,
+            accessToken,
+            "/admin/theaters/" + id,
+            updateTheaterRequest,
+            new ParameterizedTypeReference<>() {
+            });
+
+        // Assert
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        TheaterResponse body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.id()).isEqualTo(id);
+        assertThat(body.name()).isEqualTo(updateTheaterRequest.name());
+        assertThat(body.address()).isEqualTo(updateTheaterRequest.address());
+    }
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 존재하지_않는_영화관_아이디를_사용해_수정하면_Not_Found_상태코드를_반환한다(
+        Credentials credentials,
+        long id,
+        TheaterRequest theaterRequest,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+
+        // Act
+        ResponseEntity<TheaterResponse> response = putWithToken(client,
+            accessToken,
+            "/admin/theaters/" + id,
+            theaterRequest,
+            new ParameterizedTypeReference<>() {
+            });
+
+        // Asssert
+        assertThat(response.getStatusCode().value()).isEqualTo(404);
+    }
+}


### PR DESCRIPTION
#5, #6, #7, #8 이슈에 대한 작업 내용입니다.

- 영화관 등록
  - POST `/admin/theaters` 
  - Body : {“name”: {name}, “address”: {address}}
- 영화관 수정
  - PUT `/admin/theaters/{id}`
  - Body : {“name”: {name}, “address”: {address}}
- 영화관 삭제
  - DELETE `/admin/theaters/{id}`
- 아이디를 사용한 영화관 단건 조회
  - GET `/theaters/{id}`
- 검색 조건을 사용한 영화관 목록 조회
  - GET `/theaters?pageNumber={pageNumber}&pageSize={pageSize}&name={name}&address={address}`
  - 검색조건
    - name(이름): 이름에 검색어가 포함된 영화관 조회 (like 검색)
    - address(주소): 주소에 검색어가 포함된 영화관 조회 (like 검색)