### PR TITLE
상영시간표 등록/수정/삭제/조회 기능 추가

### DIFF
--- a/src/main/java/com/kjh/ticketreserve/MovieResponse.java
+++ b/src/main/java/com/kjh/ticketreserve/MovieResponse.java
@@ -1,6 +1,12 @@
 package com.kjh.ticketreserve;
 
+import com.kjh.ticketreserve.model.Movie;
+
 import java.time.LocalDateTime;
 
 public record MovieResponse(long id, String title, LocalDateTime startDate, LocalDateTime endDate, int price) {
+
+    public MovieResponse(Movie movie) {
+        this(movie.getId(), movie.getTitle(), movie.getStartDate(), movie.getEndDate(), movie.getPrice());
+    }
 }

--- a/src/main/java/com/kjh/ticketreserve/ShowtimeRequest.java
+++ b/src/main/java/com/kjh/ticketreserve/ShowtimeRequest.java
@@ -3,11 +3,11 @@ package com.kjh.ticketreserve;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
-public record ShowtimeRequest(long movieId, long theaterId, LocalDateTime showtime) {
+public record ShowtimeRequest(long movieId, long theaterId, LocalDateTime showDatetime) {
 
-    public ShowtimeRequest(long movieId, long theaterId, LocalDateTime showtime) {
+    public ShowtimeRequest(long movieId, long theaterId, LocalDateTime showDatetime) {
         this.movieId = movieId;
         this.theaterId = theaterId;
-        this.showtime = showtime.truncatedTo(ChronoUnit.SECONDS);
+        this.showDatetime = showDatetime.truncatedTo(ChronoUnit.SECONDS);
     }
 }

--- a/src/main/java/com/kjh/ticketreserve/ShowtimeRequest.java
+++ b/src/main/java/com/kjh/ticketreserve/ShowtimeRequest.java
@@ -1,0 +1,13 @@
+package com.kjh.ticketreserve;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+public record ShowtimeRequest(long movieId, long theaterId, LocalDateTime showtime) {
+
+    public ShowtimeRequest(long movieId, long theaterId, LocalDateTime showtime) {
+        this.movieId = movieId;
+        this.theaterId = theaterId;
+        this.showtime = showtime.truncatedTo(ChronoUnit.SECONDS);
+    }
+}

--- a/src/main/java/com/kjh/ticketreserve/ShowtimeResponse.java
+++ b/src/main/java/com/kjh/ticketreserve/ShowtimeResponse.java
@@ -2,5 +2,5 @@ package com.kjh.ticketreserve;
 
 import java.time.LocalDateTime;
 
-public record ShowtimeResponse(long id, MovieResponse movie, TheaterResponse theater, LocalDateTime showtime) {
+public record ShowtimeResponse(long id, MovieResponse movie, TheaterResponse theater, LocalDateTime showDatetime) {
 }

--- a/src/main/java/com/kjh/ticketreserve/ShowtimeResponse.java
+++ b/src/main/java/com/kjh/ticketreserve/ShowtimeResponse.java
@@ -1,0 +1,6 @@
+package com.kjh.ticketreserve;
+
+import java.time.LocalDateTime;
+
+public record ShowtimeResponse(long id, MovieResponse movie, TheaterResponse theater, LocalDateTime showtime) {
+}

--- a/src/main/java/com/kjh/ticketreserve/ShowtimeSearchCondition.java
+++ b/src/main/java/com/kjh/ticketreserve/ShowtimeSearchCondition.java
@@ -3,7 +3,12 @@ package com.kjh.ticketreserve;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-public record ShowtimeSearchCondition(Long movieId, Long theaterId, LocalDateTime showtimeFrom, LocalDateTime showtimeTo) {
+public record ShowtimeSearchCondition(
+    Long movieId,
+    Long theaterId,
+    LocalDateTime showDatetimeFrom,
+    LocalDateTime showDatetimeTo
+) {
 
     public ShowtimeSearchCondition(Long movieId, Long theaterId, LocalDate date) {
         this(movieId,

--- a/src/main/java/com/kjh/ticketreserve/ShowtimeSearchCondition.java
+++ b/src/main/java/com/kjh/ticketreserve/ShowtimeSearchCondition.java
@@ -1,0 +1,14 @@
+package com.kjh.ticketreserve;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record ShowtimeSearchCondition(Long movieId, Long theaterId, LocalDateTime showtimeFrom, LocalDateTime showtimeTo) {
+
+    public ShowtimeSearchCondition(Long movieId, Long theaterId, LocalDate date) {
+        this(movieId,
+            theaterId,
+            date == null ? null : date.atStartOfDay(),
+            date == null ? null : date.plusDays(1).atStartOfDay());
+    }
+}

--- a/src/main/java/com/kjh/ticketreserve/ShowtimeUpdateRequest.java
+++ b/src/main/java/com/kjh/ticketreserve/ShowtimeUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.kjh.ticketreserve;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+public record ShowtimeUpdateRequest(LocalDateTime showtime) {
+
+    public ShowtimeUpdateRequest(LocalDateTime showtime) {
+        this.showtime = showtime.truncatedTo(ChronoUnit.SECONDS);
+    }
+}

--- a/src/main/java/com/kjh/ticketreserve/ShowtimeUpdateRequest.java
+++ b/src/main/java/com/kjh/ticketreserve/ShowtimeUpdateRequest.java
@@ -3,9 +3,9 @@ package com.kjh.ticketreserve;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
-public record ShowtimeUpdateRequest(LocalDateTime showtime) {
+public record ShowtimeUpdateRequest(LocalDateTime showDatetime) {
 
-    public ShowtimeUpdateRequest(LocalDateTime showtime) {
-        this.showtime = showtime.truncatedTo(ChronoUnit.SECONDS);
+    public ShowtimeUpdateRequest(LocalDateTime showDatetime) {
+        this.showDatetime = showDatetime.truncatedTo(ChronoUnit.SECONDS);
     }
 }

--- a/src/main/java/com/kjh/ticketreserve/TheaterRequest.java
+++ b/src/main/java/com/kjh/ticketreserve/TheaterRequest.java
@@ -1,0 +1,4 @@
+package com.kjh.ticketreserve;
+
+public record TheaterRequest(String name, String address) {
+}

--- a/src/main/java/com/kjh/ticketreserve/TheaterResponse.java
+++ b/src/main/java/com/kjh/ticketreserve/TheaterResponse.java
@@ -1,4 +1,10 @@
 package com.kjh.ticketreserve;
 
+import com.kjh.ticketreserve.model.Theater;
+
 public record TheaterResponse(long id, String name, String address) {
+
+    public TheaterResponse(Theater theater) {
+        this(theater.getId(), theater.getName(), theater.getAddress());
+    }
 }

--- a/src/main/java/com/kjh/ticketreserve/TheaterResponse.java
+++ b/src/main/java/com/kjh/ticketreserve/TheaterResponse.java
@@ -1,0 +1,4 @@
+package com.kjh.ticketreserve;
+
+public record TheaterResponse(long id, String name, String address) {
+}

--- a/src/main/java/com/kjh/ticketreserve/TheaterSearchCondition.java
+++ b/src/main/java/com/kjh/ticketreserve/TheaterSearchCondition.java
@@ -1,0 +1,4 @@
+package com.kjh.ticketreserve;
+
+public record TheaterSearchCondition(String name, String address) {
+}

--- a/src/main/java/com/kjh/ticketreserve/controller/ShowtimeController.java
+++ b/src/main/java/com/kjh/ticketreserve/controller/ShowtimeController.java
@@ -1,9 +1,6 @@
 package com.kjh.ticketreserve.controller;
 
-import com.kjh.ticketreserve.MovieResponse;
-import com.kjh.ticketreserve.ShowtimeRequest;
-import com.kjh.ticketreserve.ShowtimeResponse;
-import com.kjh.ticketreserve.TheaterResponse;
+import com.kjh.ticketreserve.*;
 import com.kjh.ticketreserve.model.Movie;
 import com.kjh.ticketreserve.model.Showtime;
 import com.kjh.ticketreserve.model.Theater;
@@ -47,6 +44,17 @@ public class ShowtimeController {
     @GetMapping("/showtimes/{id}")
     public ResponseEntity<ShowtimeResponse> getShowtime(@PathVariable long id) {
         Showtime showtime = showtimeService.getShowtime(id);
+        return ResponseEntity.status(200).body(new ShowtimeResponse(
+            showtime.getId(),
+            new MovieResponse(showtime.getMovie()),
+            new TheaterResponse(showtime.getTheater()),
+            showtime.getShowtime()));
+    }
+
+    @PutMapping("/admin/showtimes/{id}")
+    public ResponseEntity<ShowtimeResponse> updateShowtime(@PathVariable long id,
+                                                           @RequestBody ShowtimeUpdateRequest showtimeUpdateRequest) {
+        Showtime showtime = showtimeService.updateShowtime(id, showtimeUpdateRequest);
         return ResponseEntity.status(200).body(new ShowtimeResponse(
             showtime.getId(),
             new MovieResponse(showtime.getMovie()),

--- a/src/main/java/com/kjh/ticketreserve/controller/ShowtimeController.java
+++ b/src/main/java/com/kjh/ticketreserve/controller/ShowtimeController.java
@@ -1,0 +1,56 @@
+package com.kjh.ticketreserve.controller;
+
+import com.kjh.ticketreserve.MovieResponse;
+import com.kjh.ticketreserve.ShowtimeRequest;
+import com.kjh.ticketreserve.ShowtimeResponse;
+import com.kjh.ticketreserve.TheaterResponse;
+import com.kjh.ticketreserve.model.Movie;
+import com.kjh.ticketreserve.model.Showtime;
+import com.kjh.ticketreserve.model.Theater;
+import com.kjh.ticketreserve.service.MovieService;
+import com.kjh.ticketreserve.service.ShowtimeService;
+import com.kjh.ticketreserve.service.TheaterService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class ShowtimeController {
+
+    private final ShowtimeService showtimeService;
+    private final MovieService movieService;
+    private final TheaterService theaterService;
+
+    public ShowtimeController(ShowtimeService showtimeService,
+                              MovieService movieService,
+                              TheaterService theaterService) {
+        this.showtimeService = showtimeService;
+        this.movieService = movieService;
+        this.theaterService = theaterService;
+    }
+
+    @PostMapping("/admin/showtimes")
+    public ResponseEntity<ShowtimeResponse> createShowtime(@RequestBody ShowtimeRequest showtimeRequest) {
+        Movie movie = movieService.getMovie(showtimeRequest.movieId());
+        Theater theater = theaterService.getTheater(showtimeRequest.theaterId());
+        Showtime showtime = new Showtime();
+        showtime.setMovie(movie);
+        showtime.setTheater(theater);
+        showtime.setShowtime(showtimeRequest.showtime());
+        showtimeService.createShowtime(showtime);
+        return ResponseEntity.status(201).body(new ShowtimeResponse(
+            showtime.getId(),
+            new MovieResponse(movie),
+            new TheaterResponse(theater),
+            showtime.getShowtime()));
+    }
+
+    @GetMapping("/showtimes/{id}")
+    public ResponseEntity<ShowtimeResponse> getShowtime(@PathVariable long id) {
+        Showtime showtime = showtimeService.getShowtime(id);
+        return ResponseEntity.status(200).body(new ShowtimeResponse(
+            showtime.getId(),
+            new MovieResponse(showtime.getMovie()),
+            new TheaterResponse(showtime.getTheater()),
+            showtime.getShowtime()));
+    }
+}

--- a/src/main/java/com/kjh/ticketreserve/controller/ShowtimeController.java
+++ b/src/main/java/com/kjh/ticketreserve/controller/ShowtimeController.java
@@ -35,13 +35,13 @@ public class ShowtimeController {
         Showtime showtime = new Showtime();
         showtime.setMovie(movie);
         showtime.setTheater(theater);
-        showtime.setShowtime(showtimeRequest.showtime());
+        showtime.setShowDatetime(showtimeRequest.showDatetime());
         showtimeService.createShowtime(showtime);
         return ResponseEntity.status(201).body(new ShowtimeResponse(
             showtime.getId(),
             new MovieResponse(movie),
             new TheaterResponse(theater),
-            showtime.getShowtime()));
+            showtime.getShowDatetime()));
     }
 
     @GetMapping("/showtimes/{id}")
@@ -51,7 +51,7 @@ public class ShowtimeController {
             showtime.getId(),
             new MovieResponse(showtime.getMovie()),
             new TheaterResponse(showtime.getTheater()),
-            showtime.getShowtime()));
+            showtime.getShowDatetime()));
     }
 
     @PutMapping("/admin/showtimes/{id}")
@@ -62,7 +62,7 @@ public class ShowtimeController {
             showtime.getId(),
             new MovieResponse(showtime.getMovie()),
             new TheaterResponse(showtime.getTheater()),
-            showtime.getShowtime()));
+            showtime.getShowDatetime()));
     }
 
     @DeleteMapping("/admin/showtimes/{id}")
@@ -84,6 +84,6 @@ public class ShowtimeController {
             s -> new ShowtimeResponse(s.getId(),
                 new MovieResponse(s.getMovie()),
                 new TheaterResponse(s.getTheater()),
-                s.getShowtime())));
+                s.getShowDatetime())));
     }
 }

--- a/src/main/java/com/kjh/ticketreserve/controller/ShowtimeController.java
+++ b/src/main/java/com/kjh/ticketreserve/controller/ShowtimeController.java
@@ -7,8 +7,11 @@ import com.kjh.ticketreserve.model.Theater;
 import com.kjh.ticketreserve.service.MovieService;
 import com.kjh.ticketreserve.service.ShowtimeService;
 import com.kjh.ticketreserve.service.TheaterService;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @RestController
 public class ShowtimeController {
@@ -66,5 +69,21 @@ public class ShowtimeController {
     public ResponseEntity<Object> deleteShowtime(@PathVariable long id) {
         showtimeService.deleteShowtime(id);
         return ResponseEntity.status(200).build();
+    }
+
+    @GetMapping("/showtimes")
+    public ResponseEntity<PageResponse<ShowtimeResponse>> searchShowtimes(
+        @RequestParam int pageNumber,
+        @RequestParam int pageSize,
+        @RequestParam(required = false) Long movieId,
+        @RequestParam(required = false) Long theaterId,
+        @RequestParam(required = false) LocalDate date
+    ) {
+        Page<Showtime> showtimePage = showtimeService.searchShowtimes(pageNumber, pageSize, movieId, theaterId, date);
+        return ResponseEntity.status(200).body(new PageResponse<>(showtimePage,
+            s -> new ShowtimeResponse(s.getId(),
+                new MovieResponse(s.getMovie()),
+                new TheaterResponse(s.getTheater()),
+                s.getShowtime())));
     }
 }

--- a/src/main/java/com/kjh/ticketreserve/controller/ShowtimeController.java
+++ b/src/main/java/com/kjh/ticketreserve/controller/ShowtimeController.java
@@ -61,4 +61,10 @@ public class ShowtimeController {
             new TheaterResponse(showtime.getTheater()),
             showtime.getShowtime()));
     }
+
+    @DeleteMapping("/admin/showtimes/{id}")
+    public ResponseEntity<Object> deleteShowtime(@PathVariable long id) {
+        showtimeService.deleteShowtime(id);
+        return ResponseEntity.status(200).build();
+    }
 }

--- a/src/main/java/com/kjh/ticketreserve/controller/TheaterController.java
+++ b/src/main/java/com/kjh/ticketreserve/controller/TheaterController.java
@@ -48,4 +48,10 @@ public class TheaterController {
             theater.getName(),
             theater.getAddress()));
     }
+
+    @DeleteMapping("/admin/theaters/{id}")
+    public ResponseEntity<TheaterResponse> deleteTheater(@PathVariable("id") Long id) {
+        theaterService.deleteTheater(id);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/kjh/ticketreserve/controller/TheaterController.java
+++ b/src/main/java/com/kjh/ticketreserve/controller/TheaterController.java
@@ -38,4 +38,14 @@ public class TheaterController {
             theater.getName(),
             theater.getAddress()));
     }
+
+    @PutMapping("/admin/theaters/{id}")
+    public ResponseEntity<TheaterResponse> updateTheater(@PathVariable("id") Long id,
+                                                         @RequestBody TheaterRequest theaterRequest) {
+        Theater theater = theaterService.updateTheater(id, theaterRequest);
+        return ResponseEntity.status(200).body(new TheaterResponse(
+            theater.getId(),
+            theater.getName(),
+            theater.getAddress()));
+    }
 }

--- a/src/main/java/com/kjh/ticketreserve/controller/TheaterController.java
+++ b/src/main/java/com/kjh/ticketreserve/controller/TheaterController.java
@@ -1,0 +1,41 @@
+package com.kjh.ticketreserve.controller;
+
+import com.kjh.ticketreserve.TheaterRequest;
+import com.kjh.ticketreserve.TheaterResponse;
+import com.kjh.ticketreserve.model.Theater;
+import com.kjh.ticketreserve.service.TheaterService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class TheaterController {
+
+    private final TheaterService theaterService;
+
+    public TheaterController(TheaterService theaterService) {
+        this.theaterService = theaterService;
+    }
+
+    @PostMapping("/admin/theaters")
+    public ResponseEntity<TheaterResponse> createTheater(@RequestBody TheaterRequest theaterRequest) {
+        Theater theater = new Theater();
+        theater.setName(theaterRequest.name());
+        theater.setAddress(theaterRequest.address());
+        theaterService.createTheater(theater);
+
+        return ResponseEntity.status(201).body(new TheaterResponse(
+            theater.getId(),
+            theater.getName(),
+            theater.getAddress()
+        ));
+    }
+
+    @GetMapping("/theaters/{id}")
+    public ResponseEntity<TheaterResponse> getTheater(@PathVariable Long id) {
+        Theater theater = theaterService.getTheater(id);
+        return ResponseEntity.status(200).body(new TheaterResponse(
+            theater.getId(),
+            theater.getName(),
+            theater.getAddress()));
+    }
+}

--- a/src/main/java/com/kjh/ticketreserve/controller/TheaterController.java
+++ b/src/main/java/com/kjh/ticketreserve/controller/TheaterController.java
@@ -1,9 +1,11 @@
 package com.kjh.ticketreserve.controller;
 
+import com.kjh.ticketreserve.PageResponse;
 import com.kjh.ticketreserve.TheaterRequest;
 import com.kjh.ticketreserve.TheaterResponse;
 import com.kjh.ticketreserve.model.Theater;
 import com.kjh.ticketreserve.service.TheaterService;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -53,5 +55,17 @@ public class TheaterController {
     public ResponseEntity<TheaterResponse> deleteTheater(@PathVariable("id") Long id) {
         theaterService.deleteTheater(id);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/theaters")
+    public ResponseEntity<PageResponse<TheaterResponse>> searchTheaters(
+        @RequestParam int pageNumber,
+        @RequestParam int pageSize,
+        @RequestParam(required = false) String name,
+        @RequestParam(required = false) String address
+    ) {
+        Page<Theater> theaterPage = theaterService.searchTheaters(pageNumber, pageSize, name, address);
+        return ResponseEntity.status(200).body(new PageResponse<>(theaterPage,
+            t -> new TheaterResponse(t.getId(), t.getName(), t.getAddress())));
     }
 }

--- a/src/main/java/com/kjh/ticketreserve/controller/UserController.java
+++ b/src/main/java/com/kjh/ticketreserve/controller/UserController.java
@@ -24,6 +24,6 @@ public class UserController {
         UserDetails userDetails = (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         return userRepository.findByEmail(userDetails.getUsername())
             .map(u -> new UserInfo(u.getEmail()))
-            .orElseThrow(NotFoundException.NOT_FOUND::get);
+            .orElseThrow(NotFoundException.NOT_FOUND_USER::get);
     }
 }

--- a/src/main/java/com/kjh/ticketreserve/exception/BadRequestException.java
+++ b/src/main/java/com/kjh/ticketreserve/exception/BadRequestException.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 
 public enum BadRequestException {
     DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
+    DUPLICATED_SHOWTIME(HttpStatus.BAD_REQUEST, "이미 존재하는 상영시간표입니다."),
     BAD_CREDENTIALS(HttpStatus.BAD_REQUEST, "이메일 또는 비밀번호가 맞지 않습니다.");
 
     private final ResponseException responseException;

--- a/src/main/java/com/kjh/ticketreserve/exception/NotFoundException.java
+++ b/src/main/java/com/kjh/ticketreserve/exception/NotFoundException.java
@@ -3,7 +3,10 @@ package com.kjh.ticketreserve.exception;
 import org.springframework.http.HttpStatus;
 
 public enum NotFoundException {
-    NOT_FOUND(HttpStatus.NOT_FOUND, "데이터를 찾을 수 없습니다.");
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."),
+    NOT_FOUND_MOVIE(HttpStatus.NOT_FOUND, "영화를 찾을 수 없습니다."),
+    NOT_FOUND_THEATER(HttpStatus.NOT_FOUND, "영화관을 찾을 수 없습니다."),
+    NOT_FOUND_SHOWTIME(HttpStatus.NOT_FOUND, "상영시간표를 찾을 수 없습니다.");
 
     private final ResponseException responseException;
 

--- a/src/main/java/com/kjh/ticketreserve/jpa/ShowtimeCustomRepository.java
+++ b/src/main/java/com/kjh/ticketreserve/jpa/ShowtimeCustomRepository.java
@@ -1,0 +1,11 @@
+package com.kjh.ticketreserve.jpa;
+
+import com.kjh.ticketreserve.ShowtimeSearchCondition;
+import com.kjh.ticketreserve.model.Showtime;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ShowtimeCustomRepository {
+
+    Page<Showtime> findAllBySearchCondition(ShowtimeSearchCondition searchCondition, Pageable pageable);
+}

--- a/src/main/java/com/kjh/ticketreserve/jpa/ShowtimeRepository.java
+++ b/src/main/java/com/kjh/ticketreserve/jpa/ShowtimeRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
 
-public interface ShowtimeRepository extends JpaRepository<Showtime, Long> {
+public interface ShowtimeRepository extends JpaRepository<Showtime, Long>, ShowtimeCustomRepository {
 
     boolean existsByMovieIdAndTheaterIdAndShowtime(Long movieId, Long theaterId, LocalDateTime showtime);
 }

--- a/src/main/java/com/kjh/ticketreserve/jpa/ShowtimeRepository.java
+++ b/src/main/java/com/kjh/ticketreserve/jpa/ShowtimeRepository.java
@@ -7,5 +7,5 @@ import java.time.LocalDateTime;
 
 public interface ShowtimeRepository extends JpaRepository<Showtime, Long>, ShowtimeCustomRepository {
 
-    boolean existsByMovieIdAndTheaterIdAndShowtime(Long movieId, Long theaterId, LocalDateTime showtime);
+    boolean existsByMovieIdAndTheaterIdAndShowDatetime(Long movieId, Long theaterId, LocalDateTime showDatetime);
 }

--- a/src/main/java/com/kjh/ticketreserve/jpa/ShowtimeRepository.java
+++ b/src/main/java/com/kjh/ticketreserve/jpa/ShowtimeRepository.java
@@ -1,0 +1,11 @@
+package com.kjh.ticketreserve.jpa;
+
+import com.kjh.ticketreserve.model.Showtime;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+
+public interface ShowtimeRepository extends JpaRepository<Showtime, Long> {
+
+    boolean existsByMovieIdAndTheaterIdAndShowtime(Long movieId, Long theaterId, LocalDateTime showtime);
+}

--- a/src/main/java/com/kjh/ticketreserve/jpa/ShowtimeRepositoryImpl.java
+++ b/src/main/java/com/kjh/ticketreserve/jpa/ShowtimeRepositoryImpl.java
@@ -1,0 +1,53 @@
+package com.kjh.ticketreserve.jpa;
+
+import com.kjh.ticketreserve.ShowtimeSearchCondition;
+import com.kjh.ticketreserve.model.Showtime;
+import com.querydsl.core.types.dsl.Wildcard;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import static com.kjh.ticketreserve.jpa.QuerydslPredicateUtils.ifNullNone;
+import static com.kjh.ticketreserve.model.QMovie.movie;
+import static com.kjh.ticketreserve.model.QShowtime.*;
+import static com.kjh.ticketreserve.model.QTheater.theater;
+
+@RequiredArgsConstructor
+public class ShowtimeRepositoryImpl implements ShowtimeCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Showtime> findAllBySearchCondition(ShowtimeSearchCondition searchCondition, Pageable pageable) {
+        JPAQuery<Showtime> query = queryFactory
+            .select(showtime1)
+            .from(showtime1)
+            .join(showtime1.movie, movie).fetchJoin()
+            .join(showtime1.theater, theater).fetchJoin()
+            .where(
+                ifNullNone(movie.id::eq, searchCondition.movieId()),
+                ifNullNone(theater.id::eq, searchCondition.theaterId()),
+                ifNullNone(showtime1.showtime::goe, searchCondition.showtimeFrom()),
+                ifNullNone(showtime1.showtime::lt, searchCondition.showtimeTo())
+            )
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize());
+
+        JPAQuery<Long> countQuery = queryFactory
+            .select(Wildcard.count)
+            .from(showtime1)
+            .where(
+                ifNullNone(showtime1.movie.id::eq, searchCondition.movieId()),
+                ifNullNone(showtime1.theater.id::eq, searchCondition.theaterId()),
+                ifNullNone(showtime1.showtime::goe, searchCondition.showtimeFrom()),
+                ifNullNone(showtime1.showtime::lt, searchCondition.showtimeTo())
+            )
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize());
+
+        return new PageImpl<>(query.fetch(), pageable, countQuery.fetch().get(0));
+    }
+}

--- a/src/main/java/com/kjh/ticketreserve/jpa/ShowtimeRepositoryImpl.java
+++ b/src/main/java/com/kjh/ticketreserve/jpa/ShowtimeRepositoryImpl.java
@@ -23,27 +23,27 @@ public class ShowtimeRepositoryImpl implements ShowtimeCustomRepository {
     @Override
     public Page<Showtime> findAllBySearchCondition(ShowtimeSearchCondition searchCondition, Pageable pageable) {
         JPAQuery<Showtime> query = queryFactory
-            .select(showtime1)
-            .from(showtime1)
-            .join(showtime1.movie, movie).fetchJoin()
-            .join(showtime1.theater, theater).fetchJoin()
+            .select(showtime)
+            .from(showtime)
+            .join(showtime.movie, movie).fetchJoin()
+            .join(showtime.theater, theater).fetchJoin()
             .where(
                 ifNullNone(movie.id::eq, searchCondition.movieId()),
                 ifNullNone(theater.id::eq, searchCondition.theaterId()),
-                ifNullNone(showtime1.showtime::goe, searchCondition.showtimeFrom()),
-                ifNullNone(showtime1.showtime::lt, searchCondition.showtimeTo())
+                ifNullNone(showtime.showDatetime::goe, searchCondition.showDatetimeFrom()),
+                ifNullNone(showtime.showDatetime::lt, searchCondition.showDatetimeTo())
             )
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize());
 
         JPAQuery<Long> countQuery = queryFactory
             .select(Wildcard.count)
-            .from(showtime1)
+            .from(showtime)
             .where(
-                ifNullNone(showtime1.movie.id::eq, searchCondition.movieId()),
-                ifNullNone(showtime1.theater.id::eq, searchCondition.theaterId()),
-                ifNullNone(showtime1.showtime::goe, searchCondition.showtimeFrom()),
-                ifNullNone(showtime1.showtime::lt, searchCondition.showtimeTo())
+                ifNullNone(showtime.movie.id::eq, searchCondition.movieId()),
+                ifNullNone(showtime.theater.id::eq, searchCondition.theaterId()),
+                ifNullNone(showtime.showDatetime::goe, searchCondition.showDatetimeFrom()),
+                ifNullNone(showtime.showDatetime::lt, searchCondition.showDatetimeTo())
             )
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize());

--- a/src/main/java/com/kjh/ticketreserve/jpa/TheaterCustomRepository.java
+++ b/src/main/java/com/kjh/ticketreserve/jpa/TheaterCustomRepository.java
@@ -1,0 +1,11 @@
+package com.kjh.ticketreserve.jpa;
+
+import com.kjh.ticketreserve.TheaterSearchCondition;
+import com.kjh.ticketreserve.model.Theater;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface TheaterCustomRepository {
+
+    Page<Theater> findAllBySearchCondition(TheaterSearchCondition searchCondition, Pageable pageable);
+}

--- a/src/main/java/com/kjh/ticketreserve/jpa/TheaterCustomRepositoryImpl.java
+++ b/src/main/java/com/kjh/ticketreserve/jpa/TheaterCustomRepositoryImpl.java
@@ -1,0 +1,43 @@
+package com.kjh.ticketreserve.jpa;
+
+import com.kjh.ticketreserve.TheaterSearchCondition;
+import com.kjh.ticketreserve.model.Theater;
+import com.querydsl.core.types.dsl.Wildcard;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import static com.kjh.ticketreserve.jpa.QuerydslPredicateUtils.ifNullNone;
+import static com.kjh.ticketreserve.model.QTheater.theater;
+
+@RequiredArgsConstructor
+public class TheaterCustomRepositoryImpl implements TheaterCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Theater> findAllBySearchCondition(TheaterSearchCondition searchCondition, Pageable pageable) {
+        JPAQuery<Theater> query = queryFactory
+            .select(theater)
+            .from(theater)
+            .where(
+                ifNullNone(theater.name::contains, searchCondition.name()),
+                ifNullNone(theater.address::contains, searchCondition.address())
+            )
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize());
+
+        JPAQuery<Long> countQuery = queryFactory
+            .select(Wildcard.count)
+            .from(theater)
+            .where(
+                ifNullNone(theater.name::contains, searchCondition.name()),
+                ifNullNone(theater.address::contains, searchCondition.address())
+            );
+
+        return new PageImpl<>(query.fetch(), pageable, countQuery.fetch().get(0));
+    }
+}

--- a/src/main/java/com/kjh/ticketreserve/jpa/TheaterRepository.java
+++ b/src/main/java/com/kjh/ticketreserve/jpa/TheaterRepository.java
@@ -1,0 +1,7 @@
+package com.kjh.ticketreserve.jpa;
+
+import com.kjh.ticketreserve.model.Theater;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TheaterRepository extends JpaRepository<Theater, Long> {
+}

--- a/src/main/java/com/kjh/ticketreserve/jpa/TheaterRepository.java
+++ b/src/main/java/com/kjh/ticketreserve/jpa/TheaterRepository.java
@@ -3,5 +3,5 @@ package com.kjh.ticketreserve.jpa;
 import com.kjh.ticketreserve.model.Theater;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TheaterRepository extends JpaRepository<Theater, Long> {
+public interface TheaterRepository extends JpaRepository<Theater, Long>, TheaterCustomRepository {
 }

--- a/src/main/java/com/kjh/ticketreserve/model/Showtime.java
+++ b/src/main/java/com/kjh/ticketreserve/model/Showtime.java
@@ -1,0 +1,31 @@
+package com.kjh.ticketreserve.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Table(
+    uniqueConstraints = @UniqueConstraint(columnNames = { "movie_id", "theater_id", "showtime" }))
+@NoArgsConstructor
+public class Showtime {
+
+    @Id
+    @GeneratedValue
+    Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "movie_id", nullable = false)
+    private Movie movie;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "theater_id", nullable = false)
+    private Theater theater;
+
+    private LocalDateTime showtime;
+}

--- a/src/main/java/com/kjh/ticketreserve/model/Showtime.java
+++ b/src/main/java/com/kjh/ticketreserve/model/Showtime.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @Table(
-    uniqueConstraints = @UniqueConstraint(columnNames = { "movie_id", "theater_id", "showtime" }))
+    uniqueConstraints = @UniqueConstraint(columnNames = { "movie_id", "theater_id", "show_datetime" }))
 @NoArgsConstructor
 public class Showtime {
 
@@ -27,5 +27,5 @@ public class Showtime {
     @JoinColumn(name = "theater_id", nullable = false)
     private Theater theater;
 
-    private LocalDateTime showtime;
+    private LocalDateTime showDatetime;
 }

--- a/src/main/java/com/kjh/ticketreserve/model/Theater.java
+++ b/src/main/java/com/kjh/ticketreserve/model/Theater.java
@@ -1,0 +1,21 @@
+package com.kjh.ticketreserve.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class Theater {
+
+    @Id
+    @GeneratedValue
+    Long id;
+    private String name;
+    private String address;
+}

--- a/src/main/java/com/kjh/ticketreserve/service/MovieService.java
+++ b/src/main/java/com/kjh/ticketreserve/service/MovieService.java
@@ -23,12 +23,12 @@ public class MovieService {
 
     @Transactional(readOnly = true)
     public Movie getMovie(long id) {
-        return movieRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND::get);
+        return movieRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND_MOVIE::get);
     }
 
     @Transactional
     public Movie updateMovie(long id, MovieRequest movieRequest) {
-        Movie movie = movieRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND::get);
+        Movie movie = movieRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND_MOVIE::get);
         movie.setTitle(movieRequest.title());
         movie.setStartDate(movieRequest.startDate());
         movie.setEndDate(movieRequest.endDate());
@@ -38,7 +38,7 @@ public class MovieService {
 
     @Transactional
     public void deleteMovie(long id) {
-        Movie movie = movieRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND::get);
+        Movie movie = movieRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND_MOVIE::get);
         movieRepository.delete(movie);
     }
 

--- a/src/main/java/com/kjh/ticketreserve/service/ShowtimeService.java
+++ b/src/main/java/com/kjh/ticketreserve/service/ShowtimeService.java
@@ -1,0 +1,34 @@
+package com.kjh.ticketreserve.service;
+
+import com.kjh.ticketreserve.exception.BadRequestException;
+import com.kjh.ticketreserve.exception.NotFoundException;
+import com.kjh.ticketreserve.jpa.ShowtimeRepository;
+import com.kjh.ticketreserve.model.Showtime;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ShowtimeService {
+
+    private final ShowtimeRepository showtimeRepository;
+
+    public ShowtimeService(ShowtimeRepository showtimeRepository) {
+        this.showtimeRepository = showtimeRepository;
+    }
+
+    @Transactional
+    public void createShowtime(Showtime showtime) {
+        boolean exists = showtimeRepository.existsByMovieIdAndTheaterIdAndShowtime(showtime.getMovie().getId(),
+            showtime.getTheater().getId(),
+            showtime.getShowtime());
+        if (exists) {
+            throw BadRequestException.DUPLICATED_SHOWTIME.get();
+        }
+        showtimeRepository.save(showtime);
+    }
+
+    @Transactional(readOnly = true)
+    public Showtime getShowtime(long id) {
+        return showtimeRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND_SHOWTIME::get);
+    }
+}

--- a/src/main/java/com/kjh/ticketreserve/service/ShowtimeService.java
+++ b/src/main/java/com/kjh/ticketreserve/service/ShowtimeService.java
@@ -39,4 +39,10 @@ public class ShowtimeService {
         showtime.setShowtime(showtimeUpdateRequest.showtime());
         return showtime;
     }
+
+    @Transactional
+    public void deleteShowtime(long id) {
+        Showtime showtime = showtimeRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND_SHOWTIME::get);
+        showtimeRepository.delete(showtime);
+    }
 }

--- a/src/main/java/com/kjh/ticketreserve/service/ShowtimeService.java
+++ b/src/main/java/com/kjh/ticketreserve/service/ShowtimeService.java
@@ -1,12 +1,17 @@
 package com.kjh.ticketreserve.service;
 
+import com.kjh.ticketreserve.ShowtimeSearchCondition;
 import com.kjh.ticketreserve.ShowtimeUpdateRequest;
 import com.kjh.ticketreserve.exception.BadRequestException;
 import com.kjh.ticketreserve.exception.NotFoundException;
 import com.kjh.ticketreserve.jpa.ShowtimeRepository;
 import com.kjh.ticketreserve.model.Showtime;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
 
 @Service
 public class ShowtimeService {
@@ -44,5 +49,11 @@ public class ShowtimeService {
     public void deleteShowtime(long id) {
         Showtime showtime = showtimeRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND_SHOWTIME::get);
         showtimeRepository.delete(showtime);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Showtime> searchShowtimes(int pageNumber, int pageSize, Long movieId, Long theaterId, LocalDate date) {
+        ShowtimeSearchCondition searchCondition = new ShowtimeSearchCondition(movieId, theaterId, date);
+        return showtimeRepository.findAllBySearchCondition(searchCondition, PageRequest.of(pageNumber, pageSize));
     }
 }

--- a/src/main/java/com/kjh/ticketreserve/service/ShowtimeService.java
+++ b/src/main/java/com/kjh/ticketreserve/service/ShowtimeService.java
@@ -1,5 +1,6 @@
 package com.kjh.ticketreserve.service;
 
+import com.kjh.ticketreserve.ShowtimeUpdateRequest;
 import com.kjh.ticketreserve.exception.BadRequestException;
 import com.kjh.ticketreserve.exception.NotFoundException;
 import com.kjh.ticketreserve.jpa.ShowtimeRepository;
@@ -30,5 +31,12 @@ public class ShowtimeService {
     @Transactional(readOnly = true)
     public Showtime getShowtime(long id) {
         return showtimeRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND_SHOWTIME::get);
+    }
+
+    @Transactional
+    public Showtime updateShowtime(long id, ShowtimeUpdateRequest showtimeUpdateRequest) {
+        Showtime showtime = showtimeRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND_SHOWTIME::get);
+        showtime.setShowtime(showtimeUpdateRequest.showtime());
+        return showtime;
     }
 }

--- a/src/main/java/com/kjh/ticketreserve/service/ShowtimeService.java
+++ b/src/main/java/com/kjh/ticketreserve/service/ShowtimeService.java
@@ -24,9 +24,9 @@ public class ShowtimeService {
 
     @Transactional
     public void createShowtime(Showtime showtime) {
-        boolean exists = showtimeRepository.existsByMovieIdAndTheaterIdAndShowtime(showtime.getMovie().getId(),
+        boolean exists = showtimeRepository.existsByMovieIdAndTheaterIdAndShowDatetime(showtime.getMovie().getId(),
             showtime.getTheater().getId(),
-            showtime.getShowtime());
+            showtime.getShowDatetime());
         if (exists) {
             throw BadRequestException.DUPLICATED_SHOWTIME.get();
         }
@@ -41,7 +41,7 @@ public class ShowtimeService {
     @Transactional
     public Showtime updateShowtime(long id, ShowtimeUpdateRequest showtimeUpdateRequest) {
         Showtime showtime = showtimeRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND_SHOWTIME::get);
-        showtime.setShowtime(showtimeUpdateRequest.showtime());
+        showtime.setShowDatetime(showtimeUpdateRequest.showDatetime());
         return showtime;
     }
 

--- a/src/main/java/com/kjh/ticketreserve/service/TheaterService.java
+++ b/src/main/java/com/kjh/ticketreserve/service/TheaterService.java
@@ -1,9 +1,12 @@
 package com.kjh.ticketreserve.service;
 
 import com.kjh.ticketreserve.TheaterRequest;
+import com.kjh.ticketreserve.TheaterSearchCondition;
 import com.kjh.ticketreserve.exception.NotFoundException;
 import com.kjh.ticketreserve.jpa.TheaterRepository;
 import com.kjh.ticketreserve.model.Theater;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,5 +41,11 @@ public class TheaterService {
     public void deleteTheater(long id) {
         Theater theater = theaterRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND::get);
         theaterRepository.delete(theater);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Theater> searchTheaters(int pageNumber, int pageSize, String name, String address) {
+        TheaterSearchCondition searchCondition = new TheaterSearchCondition(name, address);
+        return theaterRepository.findAllBySearchCondition(searchCondition, PageRequest.of(pageNumber, pageSize));
     }
 }

--- a/src/main/java/com/kjh/ticketreserve/service/TheaterService.java
+++ b/src/main/java/com/kjh/ticketreserve/service/TheaterService.java
@@ -1,5 +1,6 @@
 package com.kjh.ticketreserve.service;
 
+import com.kjh.ticketreserve.TheaterRequest;
 import com.kjh.ticketreserve.exception.NotFoundException;
 import com.kjh.ticketreserve.jpa.TheaterRepository;
 import com.kjh.ticketreserve.model.Theater;
@@ -23,5 +24,13 @@ public class TheaterService {
     @Transactional(readOnly = true)
     public Theater getTheater(long id) {
         return theaterRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND::get);
+    }
+
+    @Transactional
+    public Theater updateTheater(long id, TheaterRequest theaterRequest) {
+        Theater theater = theaterRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND::get);
+        theater.setName(theaterRequest.name());
+        theater.setAddress(theaterRequest.address());
+        return theater;
     }
 }

--- a/src/main/java/com/kjh/ticketreserve/service/TheaterService.java
+++ b/src/main/java/com/kjh/ticketreserve/service/TheaterService.java
@@ -33,4 +33,10 @@ public class TheaterService {
         theater.setAddress(theaterRequest.address());
         return theater;
     }
+
+    @Transactional
+    public void deleteTheater(long id) {
+        Theater theater = theaterRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND::get);
+        theaterRepository.delete(theater);
+    }
 }

--- a/src/main/java/com/kjh/ticketreserve/service/TheaterService.java
+++ b/src/main/java/com/kjh/ticketreserve/service/TheaterService.java
@@ -26,12 +26,12 @@ public class TheaterService {
 
     @Transactional(readOnly = true)
     public Theater getTheater(long id) {
-        return theaterRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND::get);
+        return theaterRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND_THEATER::get);
     }
 
     @Transactional
     public Theater updateTheater(long id, TheaterRequest theaterRequest) {
-        Theater theater = theaterRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND::get);
+        Theater theater = theaterRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND_THEATER::get);
         theater.setName(theaterRequest.name());
         theater.setAddress(theaterRequest.address());
         return theater;
@@ -39,7 +39,7 @@ public class TheaterService {
 
     @Transactional
     public void deleteTheater(long id) {
-        Theater theater = theaterRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND::get);
+        Theater theater = theaterRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND_THEATER::get);
         theaterRepository.delete(theater);
     }
 

--- a/src/main/java/com/kjh/ticketreserve/service/TheaterService.java
+++ b/src/main/java/com/kjh/ticketreserve/service/TheaterService.java
@@ -1,0 +1,27 @@
+package com.kjh.ticketreserve.service;
+
+import com.kjh.ticketreserve.exception.NotFoundException;
+import com.kjh.ticketreserve.jpa.TheaterRepository;
+import com.kjh.ticketreserve.model.Theater;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class TheaterService {
+
+    private final TheaterRepository theaterRepository;
+
+    public TheaterService(TheaterRepository theaterRepository) {
+        this.theaterRepository = theaterRepository;
+    }
+
+    @Transactional
+    public void createTheater(Theater theater) {
+        theaterRepository.save(theater);
+    }
+
+    @Transactional(readOnly = true)
+    public Theater getTheater(long id) {
+        return theaterRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND::get);
+    }
+}

--- a/src/test/java/com/kjh/ticketreserve/TestLanguage.java
+++ b/src/test/java/com/kjh/ticketreserve/TestLanguage.java
@@ -143,4 +143,20 @@ public class TestLanguage {
 
         return response.getBody().id();
     }
+
+    @SuppressWarnings("DataFlowIssue")
+    public static long createShowtime(
+        TestRestTemplate client,
+        String accessToken,
+        ShowtimeRequest showtimeRequest) {
+
+        ResponseEntity<ShowtimeResponse> response = postWithToken(client,
+            accessToken,
+            "/admin/showtimes",
+            showtimeRequest,
+            new ParameterizedTypeReference<>() {
+            });
+
+        return response.getBody().id();
+    }
 }

--- a/src/test/java/com/kjh/ticketreserve/TestLanguage.java
+++ b/src/test/java/com/kjh/ticketreserve/TestLanguage.java
@@ -127,4 +127,16 @@ public class TestLanguage {
 
         return response.getBody().id();
     }
+
+    @SuppressWarnings("DataFlowIssue")
+    public static long createTheater(TheaterRequest theaterRequest, TestRestTemplate client, String accessToken) {
+        ResponseEntity<TheaterResponse> response = postWithToken(client,
+            accessToken,
+            "/admin/theaters",
+            theaterRequest,
+            new ParameterizedTypeReference<>() {
+            });
+
+        return response.getBody().id();
+    }
 }

--- a/src/test/java/com/kjh/ticketreserve/TestLanguage.java
+++ b/src/test/java/com/kjh/ticketreserve/TestLanguage.java
@@ -129,7 +129,11 @@ public class TestLanguage {
     }
 
     @SuppressWarnings("DataFlowIssue")
-    public static long createTheater(TheaterRequest theaterRequest, TestRestTemplate client, String accessToken) {
+    public static long createTheater(
+        TestRestTemplate client,
+        String accessToken,
+        TheaterRequest theaterRequest) {
+
         ResponseEntity<TheaterResponse> response = postWithToken(client,
             accessToken,
             "/admin/theaters",

--- a/src/test/java/com/kjh/ticketreserve/showtime/DeleteTests.java
+++ b/src/test/java/com/kjh/ticketreserve/showtime/DeleteTests.java
@@ -23,7 +23,7 @@ public class DeleteTests {
         Credentials credentials,
         MovieRequest movieRequest,
         TheaterRequest theaterRequest,
-        LocalDateTime showtime,
+        LocalDateTime showDatetime,
         @Autowired TestRestTemplate client
     ) {
         // Arrange
@@ -31,7 +31,7 @@ public class DeleteTests {
         String accessToken = signin(client, credentials);
         long movieId = createMovie(client, accessToken, movieRequest);
         long theaterId = createTheater(client, accessToken, theaterRequest);
-        long id = createShowtime(client, accessToken, new ShowtimeRequest(movieId, theaterId, showtime));
+        long id = createShowtime(client, accessToken, new ShowtimeRequest(movieId, theaterId, showDatetime));
 
         // Act
         ResponseEntity<Object> response = deleteWithToken(client,
@@ -49,7 +49,7 @@ public class DeleteTests {
         Credentials credentials,
         MovieRequest movieRequest,
         TheaterRequest theaterRequest,
-        LocalDateTime showtime,
+        LocalDateTime showDatetime,
         @Autowired TestRestTemplate client
     ) {
         // Arrange
@@ -57,7 +57,7 @@ public class DeleteTests {
         String accessToken = signin(client, credentials);
         long movieId = createMovie(client, accessToken, movieRequest);
         long theaterId = createTheater(client, accessToken, theaterRequest);
-        long id = createShowtime(client, accessToken, new ShowtimeRequest(movieId, theaterId, showtime));
+        long id = createShowtime(client, accessToken, new ShowtimeRequest(movieId, theaterId, showDatetime));
         deleteWithToken(client, accessToken, "/admin/showtimes/" + id, Void.class);
 
         // Act

--- a/src/test/java/com/kjh/ticketreserve/showtime/DeleteTests.java
+++ b/src/test/java/com/kjh/ticketreserve/showtime/DeleteTests.java
@@ -1,0 +1,72 @@
+package com.kjh.ticketreserve.showtime;
+
+import com.kjh.ticketreserve.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+
+import static com.kjh.ticketreserve.TestLanguage.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("DELETE /admin/showtimes")
+public class DeleteTests {
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 상영시간표_아이디를_사용해_상영시간표를_삭제하면_OK_상태코드를_반환한다(
+        Credentials credentials,
+        MovieRequest movieRequest,
+        TheaterRequest theaterRequest,
+        LocalDateTime showtime,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        long movieId = createMovie(client, accessToken, movieRequest);
+        long theaterId = createTheater(client, accessToken, theaterRequest);
+        long id = createShowtime(client, accessToken, new ShowtimeRequest(movieId, theaterId, showtime));
+
+        // Act
+        ResponseEntity<Object> response = deleteWithToken(client,
+            accessToken,
+            "/admin/showtimes/" + id,
+            Object.class);
+
+        // Assert
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+    }
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 존재하지_않는_상영시간표_아이디를_사용해_삭제하면_Not_Found_상태코드를_반환한다(
+        Credentials credentials,
+        MovieRequest movieRequest,
+        TheaterRequest theaterRequest,
+        LocalDateTime showtime,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        long movieId = createMovie(client, accessToken, movieRequest);
+        long theaterId = createTheater(client, accessToken, theaterRequest);
+        long id = createShowtime(client, accessToken, new ShowtimeRequest(movieId, theaterId, showtime));
+        deleteWithToken(client, accessToken, "/admin/showtimes/" + id, Void.class);
+
+        // Act
+        ResponseEntity<Object> response = deleteWithToken(client,
+            accessToken,
+            "/admin/showtimes/" + id,
+            Object.class);
+
+        // Assert
+        assertThat(response.getStatusCode().value()).isEqualTo(404);
+    }
+}

--- a/src/test/java/com/kjh/ticketreserve/showtime/GetTests.java
+++ b/src/test/java/com/kjh/ticketreserve/showtime/GetTests.java
@@ -1,0 +1,51 @@
+package com.kjh.ticketreserve.showtime;
+
+import com.kjh.ticketreserve.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+
+import static com.kjh.ticketreserve.TestLanguage.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("GET /showtimes")
+public class GetTests {
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 상영시간표_아이디를_사용해_조회하면_상영시간표_정보를_반환한다(
+        Credentials credentials,
+        MovieRequest movieRequest,
+        TheaterRequest theaterRequest,
+        LocalDateTime showtime,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        long movieId = createMovie(client, accessToken, movieRequest);
+        long theaterId = createTheater(client, accessToken, theaterRequest);
+        long id = createShowtime(client, accessToken, new ShowtimeRequest(movieId, theaterId, showtime));
+
+        // Act
+        ResponseEntity<ShowtimeResponse> response = getWithToken(client,
+            accessToken,
+            "/showtimes/" + id,
+            ShowtimeResponse.class);
+
+        // Assert
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        ShowtimeResponse body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.id()).isEqualTo(id);
+        assertThat(body.movie().id()).isEqualTo(movieId);
+        assertThat(body.theater().id()).isEqualTo(theaterId);
+        assertThat(body.showtime()).isEqualToIgnoringNanos(showtime);
+    }
+}

--- a/src/test/java/com/kjh/ticketreserve/showtime/GetTests.java
+++ b/src/test/java/com/kjh/ticketreserve/showtime/GetTests.java
@@ -26,7 +26,7 @@ public class GetTests {
         Credentials credentials,
         MovieRequest movieRequest,
         TheaterRequest theaterRequest,
-        LocalDateTime showtime,
+        LocalDateTime showDatetime,
         @Autowired TestRestTemplate client
     ) {
         // Arrange
@@ -34,7 +34,7 @@ public class GetTests {
         String accessToken = signin(client, credentials);
         long movieId = createMovie(client, accessToken, movieRequest);
         long theaterId = createTheater(client, accessToken, theaterRequest);
-        long id = createShowtime(client, accessToken, new ShowtimeRequest(movieId, theaterId, showtime));
+        long id = createShowtime(client, accessToken, new ShowtimeRequest(movieId, theaterId, showDatetime));
 
         // Act
         ResponseEntity<ShowtimeResponse> response = getWithToken(client,
@@ -49,7 +49,7 @@ public class GetTests {
         assertThat(body.id()).isEqualTo(id);
         assertThat(body.movie().id()).isEqualTo(movieId);
         assertThat(body.theater().id()).isEqualTo(theaterId);
-        assertThat(body.showtime()).isEqualToIgnoringNanos(showtime);
+        assertThat(body.showDatetime()).isEqualToIgnoringNanos(showDatetime);
     }
 
     @ParameterizedTest
@@ -58,7 +58,7 @@ public class GetTests {
         Credentials credentials,
         MovieRequest movieRequest,
         TheaterRequest theaterRequest,
-        List<LocalDateTime> showtimes,
+        List<LocalDateTime> showDatetimes,
         @Autowired TestRestTemplate client
     ) {
         // Arrange
@@ -66,21 +66,21 @@ public class GetTests {
         String accessToken = signin(client, credentials);
         long movieId = createMovie(client, accessToken, movieRequest);
         long theaterId = createTheater(client, accessToken, theaterRequest);
-        for (LocalDateTime showtime : showtimes) {
+        for (LocalDateTime showtime : showDatetimes) {
             createShowtime(client, accessToken, new ShowtimeRequest(movieId, theaterId, showtime));
         }
 
         // Act
         ResponseEntity<PageResponse<ShowtimeResponse>> response = getWithToken(client,
             accessToken,
-            "/showtimes?pageNumber=0&pageSize=" + showtimes.size(),
+            "/showtimes?pageNumber=0&pageSize=" + showDatetimes.size(),
             new ParameterizedTypeReference<>() {
             });
 
         // Assert
         assertThat(response.getStatusCode().value()).isEqualTo(200);
         assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().content().size()).isEqualTo(showtimes.size());
+        assertThat(response.getBody().content().size()).isEqualTo(showDatetimes.size());
     }
 
     @ParameterizedTest
@@ -89,14 +89,14 @@ public class GetTests {
         Credentials credentials,
         MovieRequest movieRequest,
         TheaterRequest theaterRequest,
-        List<LocalDateTime> showtimes,
+        List<LocalDateTime> showDatetimes,
         @Autowired TestRestTemplate client
     ) {
         // Arrange
         signup(client, credentials);
         String accessToken = signin(client, credentials);
         List<ShowtimeRequest> showtimeRequests = new ArrayList<>();
-        for (LocalDateTime showtime : showtimes) {
+        for (LocalDateTime showtime : showDatetimes) {
             long movieId = createMovie(client, accessToken, movieRequest);
             long theaterId = createTheater(client, accessToken, theaterRequest);
             ShowtimeRequest showtimeRequest = new ShowtimeRequest(movieId, theaterId, showtime);
@@ -108,7 +108,7 @@ public class GetTests {
         ShowtimeRequest showtimeToFind = showtimeRequests.get(0);
         ResponseEntity<PageResponse<ShowtimeResponse>> response = getWithToken(client,
             accessToken,
-            "/showtimes?pageNumber=0&pageSize=" + showtimes.size() + "&movieId=" + showtimeToFind.movieId(),
+            "/showtimes?pageNumber=0&pageSize=" + showDatetimes.size() + "&movieId=" + showtimeToFind.movieId(),
             new ParameterizedTypeReference<>() {
             });
 
@@ -126,14 +126,14 @@ public class GetTests {
         Credentials credentials,
         MovieRequest movieRequest,
         TheaterRequest theaterRequest,
-        List<LocalDateTime> showtimes,
+        List<LocalDateTime> showDatetimes,
         @Autowired TestRestTemplate client
     ) {
         // Arrange
         signup(client, credentials);
         String accessToken = signin(client, credentials);
         List<ShowtimeRequest> showtimeRequests = new ArrayList<>();
-        for (LocalDateTime showtime : showtimes) {
+        for (LocalDateTime showtime : showDatetimes) {
             long movieId = createMovie(client, accessToken, movieRequest);
             long theaterId = createTheater(client, accessToken, theaterRequest);
             ShowtimeRequest showtimeRequest = new ShowtimeRequest(movieId, theaterId, showtime);
@@ -145,7 +145,7 @@ public class GetTests {
         ShowtimeRequest showtimeToFind = showtimeRequests.get(0);
         ResponseEntity<PageResponse<ShowtimeResponse>> response = getWithToken(client,
             accessToken,
-            "/showtimes?pageNumber=0&pageSize=" + showtimes.size() + "&theaterId=" + showtimeToFind.theaterId(),
+            "/showtimes?pageNumber=0&pageSize=" + showDatetimes.size() + "&theaterId=" + showtimeToFind.theaterId(),
             new ParameterizedTypeReference<>() {
             });
 
@@ -163,14 +163,14 @@ public class GetTests {
         Credentials credentials,
         MovieRequest movieRequest,
         TheaterRequest theaterRequest,
-        List<LocalDateTime> showtimes,
+        List<LocalDateTime> showDatetimes,
         @Autowired TestRestTemplate client
     ) {
         // Arrange
         signup(client, credentials);
         String accessToken = signin(client, credentials);
         List<ShowtimeRequest> showtimeRequests = new ArrayList<>();
-        for (LocalDateTime showtime : showtimes) {
+        for (LocalDateTime showtime : showDatetimes) {
             long movieId = createMovie(client, accessToken, movieRequest);
             long theaterId = createTheater(client, accessToken, theaterRequest);
             ShowtimeRequest showtimeRequest = new ShowtimeRequest(movieId, theaterId, showtime);
@@ -182,8 +182,8 @@ public class GetTests {
         ShowtimeRequest showtimeToFind = showtimeRequests.get(0);
         ResponseEntity<PageResponse<ShowtimeResponse>> response = getWithToken(client,
             accessToken,
-            "/showtimes?pageNumber=0&pageSize=" + showtimes.size() +
-                "&date=" + showtimeToFind.showtime().toLocalDate(),
+            "/showtimes?pageNumber=0&pageSize=" + showDatetimes.size() +
+                "&date=" + showtimeToFind.showDatetime().toLocalDate(),
             new ParameterizedTypeReference<>() {
             });
 
@@ -192,6 +192,6 @@ public class GetTests {
         assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody().content().size()).isEqualTo(1);
         ShowtimeResponse found = response.getBody().content().get(0);
-        assertThat(found.showtime()).isEqualTo(showtimeToFind.showtime());
+        assertThat(found.showDatetime()).isEqualTo(showtimeToFind.showDatetime());
     }
 }

--- a/src/test/java/com/kjh/ticketreserve/showtime/GetTests.java
+++ b/src/test/java/com/kjh/ticketreserve/showtime/GetTests.java
@@ -6,9 +6,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.ResponseEntity;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.kjh.ticketreserve.TestLanguage.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,5 +50,148 @@ public class GetTests {
         assertThat(body.movie().id()).isEqualTo(movieId);
         assertThat(body.theater().id()).isEqualTo(theaterId);
         assertThat(body.showtime()).isEqualToIgnoringNanos(showtime);
+    }
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 상영시간표를_검색하면_상영시간표_리스트를_반환한다(
+        Credentials credentials,
+        MovieRequest movieRequest,
+        TheaterRequest theaterRequest,
+        List<LocalDateTime> showtimes,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        long movieId = createMovie(client, accessToken, movieRequest);
+        long theaterId = createTheater(client, accessToken, theaterRequest);
+        for (LocalDateTime showtime : showtimes) {
+            createShowtime(client, accessToken, new ShowtimeRequest(movieId, theaterId, showtime));
+        }
+
+        // Act
+        ResponseEntity<PageResponse<ShowtimeResponse>> response = getWithToken(client,
+            accessToken,
+            "/showtimes?pageNumber=0&pageSize=" + showtimes.size(),
+            new ParameterizedTypeReference<>() {
+            });
+
+        // Assert
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().content().size()).isEqualTo(showtimes.size());
+    }
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 영화_아이디를_사용해_검색하면_조건에_맞는_상영시간표_리스트를_반환한다(
+        Credentials credentials,
+        MovieRequest movieRequest,
+        TheaterRequest theaterRequest,
+        List<LocalDateTime> showtimes,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        List<ShowtimeRequest> showtimeRequests = new ArrayList<>();
+        for (LocalDateTime showtime : showtimes) {
+            long movieId = createMovie(client, accessToken, movieRequest);
+            long theaterId = createTheater(client, accessToken, theaterRequest);
+            ShowtimeRequest showtimeRequest = new ShowtimeRequest(movieId, theaterId, showtime);
+            createShowtime(client, accessToken, showtimeRequest);
+            showtimeRequests.add(showtimeRequest);
+        }
+
+        // Act
+        ShowtimeRequest showtimeToFind = showtimeRequests.get(0);
+        ResponseEntity<PageResponse<ShowtimeResponse>> response = getWithToken(client,
+            accessToken,
+            "/showtimes?pageNumber=0&pageSize=" + showtimes.size() + "&movieId=" + showtimeToFind.movieId(),
+            new ParameterizedTypeReference<>() {
+            });
+
+        // Assert
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().content().size()).isEqualTo(1);
+        ShowtimeResponse found = response.getBody().content().get(0);
+        assertThat(found.movie().id()).isEqualTo(showtimeToFind.movieId());
+    }
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 영화관_아이디를_사용해_검색하면_조건에_맞는_상영시간표_리스트를_반환한다(
+        Credentials credentials,
+        MovieRequest movieRequest,
+        TheaterRequest theaterRequest,
+        List<LocalDateTime> showtimes,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        List<ShowtimeRequest> showtimeRequests = new ArrayList<>();
+        for (LocalDateTime showtime : showtimes) {
+            long movieId = createMovie(client, accessToken, movieRequest);
+            long theaterId = createTheater(client, accessToken, theaterRequest);
+            ShowtimeRequest showtimeRequest = new ShowtimeRequest(movieId, theaterId, showtime);
+            createShowtime(client, accessToken, showtimeRequest);
+            showtimeRequests.add(showtimeRequest);
+        }
+
+        // Act
+        ShowtimeRequest showtimeToFind = showtimeRequests.get(0);
+        ResponseEntity<PageResponse<ShowtimeResponse>> response = getWithToken(client,
+            accessToken,
+            "/showtimes?pageNumber=0&pageSize=" + showtimes.size() + "&theaterId=" + showtimeToFind.theaterId(),
+            new ParameterizedTypeReference<>() {
+            });
+
+        // Assert
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().content().size()).isEqualTo(1);
+        ShowtimeResponse found = response.getBody().content().get(0);
+        assertThat(found.theater().id()).isEqualTo(showtimeToFind.theaterId());
+    }
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 일자를_사용해_검색하면_조건에_맞는_상영시간표_리스트를_반환한다(
+        Credentials credentials,
+        MovieRequest movieRequest,
+        TheaterRequest theaterRequest,
+        List<LocalDateTime> showtimes,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        List<ShowtimeRequest> showtimeRequests = new ArrayList<>();
+        for (LocalDateTime showtime : showtimes) {
+            long movieId = createMovie(client, accessToken, movieRequest);
+            long theaterId = createTheater(client, accessToken, theaterRequest);
+            ShowtimeRequest showtimeRequest = new ShowtimeRequest(movieId, theaterId, showtime);
+            createShowtime(client, accessToken, showtimeRequest);
+            showtimeRequests.add(showtimeRequest);
+        }
+
+        // Act
+        ShowtimeRequest showtimeToFind = showtimeRequests.get(0);
+        ResponseEntity<PageResponse<ShowtimeResponse>> response = getWithToken(client,
+            accessToken,
+            "/showtimes?pageNumber=0&pageSize=" + showtimes.size() +
+                "&date=" + showtimeToFind.showtime().toLocalDate(),
+            new ParameterizedTypeReference<>() {
+            });
+
+        // Assert
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().content().size()).isEqualTo(1);
+        ShowtimeResponse found = response.getBody().content().get(0);
+        assertThat(found.showtime()).isEqualTo(showtimeToFind.showtime());
     }
 }

--- a/src/test/java/com/kjh/ticketreserve/showtime/PostTests.java
+++ b/src/test/java/com/kjh/ticketreserve/showtime/PostTests.java
@@ -24,7 +24,7 @@ public class PostTests {
         Credentials credentials,
         MovieRequest movieRequest,
         TheaterRequest theaterRequest,
-        LocalDateTime showtime,
+        LocalDateTime showDatetime,
         @Autowired TestRestTemplate client
     ) {
         // Arrange
@@ -32,7 +32,7 @@ public class PostTests {
         String accessToken = signin(client, credentials);
         long movieId = createMovie(client, accessToken, movieRequest);
         long theaterId = createTheater(client, accessToken, theaterRequest);
-        ShowtimeRequest showtimeRequest = new ShowtimeRequest(movieId, theaterId, showtime);
+        ShowtimeRequest showtimeRequest = new ShowtimeRequest(movieId, theaterId, showDatetime);
 
         // Act
         ResponseEntity<ShowtimeResponse> response = postWithToken(client,
@@ -53,14 +53,14 @@ public class PostTests {
         Credentials credentials,
         long movieId,
         TheaterRequest theaterRequest,
-        LocalDateTime showtime,
+        LocalDateTime showDatetime,
         @Autowired TestRestTemplate client
     ) {
         // Arrange
         signup(client, credentials);
         String accessToken = signin(client, credentials);
         long theaterId = createTheater(client, accessToken, theaterRequest);
-        ShowtimeRequest showtimeRequest = new ShowtimeRequest(movieId, theaterId, showtime);
+        ShowtimeRequest showtimeRequest = new ShowtimeRequest(movieId, theaterId, showDatetime);
 
         // Act
         ResponseEntity<ShowtimeResponse> response = postWithToken(client,
@@ -80,14 +80,14 @@ public class PostTests {
         Credentials credentials,
         MovieRequest movieRequest,
         long theaterId,
-        LocalDateTime showtime,
+        LocalDateTime showDatetime,
         @Autowired TestRestTemplate client
     ) {
         // Arrange
         signup(client, credentials);
         String accessToken = signin(client, credentials);
         long movieId = createMovie(client, accessToken, movieRequest);
-        ShowtimeRequest showtimeRequest = new ShowtimeRequest(movieId, theaterId, showtime);
+        ShowtimeRequest showtimeRequest = new ShowtimeRequest(movieId, theaterId, showDatetime);
 
         // Act
         ResponseEntity<ShowtimeResponse> response = postWithToken(client,
@@ -107,7 +107,7 @@ public class PostTests {
         Credentials credentials,
         MovieRequest movieRequest,
         TheaterRequest theaterRequest,
-        LocalDateTime showtime,
+        LocalDateTime showDatetime,
         @Autowired TestRestTemplate client
     ) {
         // Arrange
@@ -115,7 +115,7 @@ public class PostTests {
         String accessToken = signin(client, credentials);
         long movieId = createMovie(client, accessToken, movieRequest);
         long theaterId = createTheater(client, accessToken, theaterRequest);
-        ShowtimeRequest showtimeRequest = new ShowtimeRequest(movieId, theaterId, showtime);
+        ShowtimeRequest showtimeRequest = new ShowtimeRequest(movieId, theaterId, showDatetime);
         createShowtime(client, accessToken, showtimeRequest);
 
         // Act

--- a/src/test/java/com/kjh/ticketreserve/showtime/PostTests.java
+++ b/src/test/java/com/kjh/ticketreserve/showtime/PostTests.java
@@ -1,0 +1,132 @@
+package com.kjh.ticketreserve.showtime;
+
+import com.kjh.ticketreserve.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+
+import static com.kjh.ticketreserve.TestLanguage.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("POST /admin/showtimes")
+public class PostTests {
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 상영시간표를_등록하면_아이디를_반환한다(
+        Credentials credentials,
+        MovieRequest movieRequest,
+        TheaterRequest theaterRequest,
+        LocalDateTime showtime,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        long movieId = createMovie(client, accessToken, movieRequest);
+        long theaterId = createTheater(client, accessToken, theaterRequest);
+        ShowtimeRequest showtimeRequest = new ShowtimeRequest(movieId, theaterId, showtime);
+
+        // Act
+        ResponseEntity<ShowtimeResponse> response = postWithToken(client,
+            accessToken,
+            "/admin/showtimes",
+            showtimeRequest,
+            new ParameterizedTypeReference<>() {
+            });
+
+        // Assert
+        assertThat(response.getStatusCode().value()).isEqualTo(201);
+        assertThat(response.getBody()).hasFieldOrProperty("id");
+    }
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 존재하지_않는_영화_아이디를_사용해_등록하면_Not_Found_상태코드를_반환한다(
+        Credentials credentials,
+        long movieId,
+        TheaterRequest theaterRequest,
+        LocalDateTime showtime,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        long theaterId = createTheater(client, accessToken, theaterRequest);
+        ShowtimeRequest showtimeRequest = new ShowtimeRequest(movieId, theaterId, showtime);
+
+        // Act
+        ResponseEntity<ShowtimeResponse> response = postWithToken(client,
+            accessToken,
+            "/admin/showtimes",
+            showtimeRequest,
+            new ParameterizedTypeReference<>() {
+            });
+
+        // Assert
+        assertThat(response.getStatusCode().value()).isEqualTo(404);
+    }
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 존재하지_않는_영화관_아이디를_사용해_등록하면_Not_Found_상태코드를_반환한다(
+        Credentials credentials,
+        MovieRequest movieRequest,
+        long theaterId,
+        LocalDateTime showtime,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        long movieId = createMovie(client, accessToken, movieRequest);
+        ShowtimeRequest showtimeRequest = new ShowtimeRequest(movieId, theaterId, showtime);
+
+        // Act
+        ResponseEntity<ShowtimeResponse> response = postWithToken(client,
+            accessToken,
+            "/admin/showtimes",
+            showtimeRequest,
+            new ParameterizedTypeReference<>() {
+            });
+
+        // Assert
+        assertThat(response.getStatusCode().value()).isEqualTo(404);
+    }
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 이미_존재하는_영화_영화관_상영시간을_사용해_등록하면_Bad_Request_상태코드를_반환한다(
+        Credentials credentials,
+        MovieRequest movieRequest,
+        TheaterRequest theaterRequest,
+        LocalDateTime showtime,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        long movieId = createMovie(client, accessToken, movieRequest);
+        long theaterId = createTheater(client, accessToken, theaterRequest);
+        ShowtimeRequest showtimeRequest = new ShowtimeRequest(movieId, theaterId, showtime);
+        createShowtime(client, accessToken, showtimeRequest);
+
+        // Act
+        ResponseEntity<ShowtimeResponse> response = postWithToken(client,
+            accessToken,
+            "/admin/showtimes",
+            showtimeRequest,
+            new ParameterizedTypeReference<>() {
+            });
+
+        // Assert
+        assertThat(response.getStatusCode().value()).isEqualTo(400);
+    }
+}

--- a/src/test/java/com/kjh/ticketreserve/showtime/PutTests.java
+++ b/src/test/java/com/kjh/ticketreserve/showtime/PutTests.java
@@ -24,8 +24,8 @@ public class PutTests {
         Credentials credentials,
         MovieRequest movieRequest,
         TheaterRequest theaterRequest,
-        LocalDateTime createShowtime,
-        LocalDateTime updateShowtime,
+        LocalDateTime createShowDatetime,
+        LocalDateTime updateShowDatetime,
         @Autowired TestRestTemplate client
     ) {
         // Arrange
@@ -33,10 +33,10 @@ public class PutTests {
         String accessToken = signin(client, credentials);
         long movieId = createMovie(client, accessToken, movieRequest);
         long theaterId = createTheater(client, accessToken, theaterRequest);
-        long id = createShowtime(client, accessToken, new ShowtimeRequest(movieId, theaterId, createShowtime));
+        long id = createShowtime(client, accessToken, new ShowtimeRequest(movieId, theaterId, createShowDatetime));
 
         // Act
-        ShowtimeUpdateRequest showtimeUpdateRequest = new ShowtimeUpdateRequest(updateShowtime);
+        ShowtimeUpdateRequest showtimeUpdateRequest = new ShowtimeUpdateRequest(updateShowDatetime);
         ResponseEntity<ShowtimeResponse> response = putWithToken(client,
             accessToken,
             "/admin/showtimes/" + id,
@@ -51,7 +51,7 @@ public class PutTests {
         assertThat(body.id()).isEqualTo(id);
         assertThat(body.movie().id()).isEqualTo(movieId);
         assertThat(body.theater().id()).isEqualTo(theaterId);
-        assertThat(body.showtime()).isEqualTo(showtimeUpdateRequest.showtime());
+        assertThat(body.showDatetime()).isEqualTo(showtimeUpdateRequest.showDatetime());
     }
 
     @ParameterizedTest

--- a/src/test/java/com/kjh/ticketreserve/showtime/PutTests.java
+++ b/src/test/java/com/kjh/ticketreserve/showtime/PutTests.java
@@ -1,4 +1,4 @@
-package com.kjh.ticketreserve.theater;
+package com.kjh.ticketreserve.showtime;
 
 import com.kjh.ticketreserve.*;
 import org.junit.jupiter.api.DisplayName;
@@ -9,49 +9,57 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.ResponseEntity;
 
+import java.time.LocalDateTime;
+
 import static com.kjh.ticketreserve.TestLanguage.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@DisplayName("PUT /admin/theaters")
+@DisplayName("PUT /admin/showtimes")
 public class PutTests {
 
     @ParameterizedTest
     @AutoDomainSource
-    void 영화관_아이디를_사용해_영화관_정보를_수정하면_수정된_정보를_반환한다(
+    void 상영시간표_아이디를_사용해_상영시간표_정보를_수정하면_수정된_정보를_반환한다(
         Credentials credentials,
-        TheaterRequest createTheaterRequest,
-        TheaterRequest updateTheaterRequest,
+        MovieRequest movieRequest,
+        TheaterRequest theaterRequest,
+        LocalDateTime createShowtime,
+        LocalDateTime updateShowtime,
         @Autowired TestRestTemplate client
     ) {
         // Arrange
         signup(client, credentials);
         String accessToken = signin(client, credentials);
-        long id = createTheater(client, accessToken, createTheaterRequest);
+        long movieId = createMovie(client, accessToken, movieRequest);
+        long theaterId = createTheater(client, accessToken, theaterRequest);
+        long id = createShowtime(client, accessToken, new ShowtimeRequest(movieId, theaterId, createShowtime));
 
         // Act
-        ResponseEntity<TheaterResponse> response = putWithToken(client,
+        ShowtimeUpdateRequest showtimeUpdateRequest = new ShowtimeUpdateRequest(updateShowtime);
+        ResponseEntity<ShowtimeResponse> response = putWithToken(client,
             accessToken,
-            "/admin/theaters/" + id,
-            updateTheaterRequest,
+            "/admin/showtimes/" + id,
+            showtimeUpdateRequest,
             new ParameterizedTypeReference<>() {
             });
 
         // Assert
         assertThat(response.getStatusCode().value()).isEqualTo(200);
-        TheaterResponse body = response.getBody();
+        ShowtimeResponse body = response.getBody();
         assertThat(body).isNotNull();
         assertThat(body.id()).isEqualTo(id);
-        assertThat(body.name()).isEqualTo(updateTheaterRequest.name());
-        assertThat(body.address()).isEqualTo(updateTheaterRequest.address());
+        assertThat(body.movie().id()).isEqualTo(movieId);
+        assertThat(body.theater().id()).isEqualTo(theaterId);
+        assertThat(body.showtime()).isEqualTo(showtimeUpdateRequest.showtime());
     }
 
     @ParameterizedTest
     @AutoDomainSource
-    void 존재하지_않는_영화관_아이디를_사용해_수정하면_Not_Found_상태코드를_반환한다(
+    void 존재하지_않는_상영시간표_아이디를_사용해_수정하면_Not_Found_상태코드를_반환한다(
         Credentials credentials,
         long id,
-        TheaterRequest theaterRequest,
+        ShowtimeUpdateRequest showtimeUpdateRequest,
         @Autowired TestRestTemplate client
     ) {
         // Arrange
@@ -59,10 +67,10 @@ public class PutTests {
         String accessToken = signin(client, credentials);
 
         // Act
-        ResponseEntity<TheaterResponse> response = putWithToken(client,
+        ResponseEntity<ShowtimeResponse> response = putWithToken(client,
             accessToken,
-            "/admin/theaters/" + id,
-            theaterRequest,
+            "/admin/showtimes/" + id,
+            showtimeUpdateRequest,
             new ParameterizedTypeReference<>() {
             });
 

--- a/src/test/java/com/kjh/ticketreserve/theater/DeleteTests.java
+++ b/src/test/java/com/kjh/ticketreserve/theater/DeleteTests.java
@@ -1,0 +1,64 @@
+package com.kjh.ticketreserve.theater;
+
+import com.kjh.ticketreserve.AutoDomainSource;
+import com.kjh.ticketreserve.Credentials;
+import com.kjh.ticketreserve.TheaterRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.ResponseEntity;
+
+import static com.kjh.ticketreserve.TestLanguage.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("DELETE /admin/theaters")
+public class DeleteTests {
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 영화관_아이디를_사용해_영화관을_삭제하면_OK_상태코드를_반환한다(
+        Credentials credentials,
+        TheaterRequest theaterRequest,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        long id = createTheater(client, accessToken, theaterRequest);
+
+        // Act
+        ResponseEntity<Object> response = deleteWithToken(client,
+            accessToken,
+            "/admin/theaters/" + id,
+            Object.class);
+
+        // Assert
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+    }
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 존재하지_않는_영화관_아이디를_사용해_삭제하면_Not_Found_상태코드를_반환한다(
+        Credentials credentials,
+        TheaterRequest theaterRequest,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        long id = createTheater(client, accessToken, theaterRequest);
+        deleteWithToken(client, accessToken, "/admin/theaters/" + id, Void.class);
+
+        // Act
+        ResponseEntity<Object> response = deleteWithToken(client,
+            accessToken,
+            "/admin/theaters/" + id,
+            Object.class);
+
+        // Assert
+        assertThat(response.getStatusCode().value()).isEqualTo(404);
+    }
+}

--- a/src/test/java/com/kjh/ticketreserve/theater/GetTests.java
+++ b/src/test/java/com/kjh/ticketreserve/theater/GetTests.java
@@ -1,15 +1,15 @@
 package com.kjh.ticketreserve.theater;
 
-import com.kjh.ticketreserve.AutoDomainSource;
-import com.kjh.ticketreserve.Credentials;
-import com.kjh.ticketreserve.TheaterRequest;
-import com.kjh.ticketreserve.TheaterResponse;
+import com.kjh.ticketreserve.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.ResponseEntity;
+
+import java.util.List;
 
 import static com.kjh.ticketreserve.TestLanguage.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,5 +43,92 @@ public class GetTests {
         assertThat(body.id()).isEqualTo(id);
         assertThat(body.name()).isEqualTo(theaterRequest.name());
         assertThat(body.address()).isEqualTo(theaterRequest.address());
+    }
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 영화관을_검색하면_영화관_리스트를_반환한다(
+        Credentials credentials,
+        List<TheaterRequest> theaterRequests,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        for (TheaterRequest theaterRequest : theaterRequests) {
+            createTheater(client, accessToken, theaterRequest);
+        }
+
+        // Act
+        ResponseEntity<PageResponse<TheaterResponse>> response = getWithToken(client,
+            accessToken,
+            "/theaters?pageNumber=0&pageSize=" + theaterRequests.size(),
+            new ParameterizedTypeReference<>() {
+            });
+
+        // Assert
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().content().size()).isEqualTo(theaterRequests.size());
+    }
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 영화관_이름을_사용해_검색하면_조건에_맞는_영화관_리스트를_반환한다(
+        Credentials credentials,
+        List<TheaterRequest> theaterRequests,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        for (TheaterRequest theaterRequest : theaterRequests) {
+            createTheater(client, accessToken, theaterRequest);
+        }
+
+        // Act
+        TheaterRequest theaterToFind = theaterRequests.get(1);
+        ResponseEntity<PageResponse<TheaterResponse>> response = getWithToken(client,
+            accessToken,
+            "/theaters?pageNumber=0&pageSize=" + theaterRequests.size() + "&name=" + theaterToFind.name(),
+            new ParameterizedTypeReference<>() {
+            });
+
+        // Assert
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().content().size()).isEqualTo(1);
+        TheaterResponse found = response.getBody().content().get(0);
+        assertThat(found.name()).isEqualTo(theaterToFind.name());
+        assertThat(found.address()).isEqualTo(theaterToFind.address());
+    }
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 영화관_주소를_사용해_검색하면_조건에_맞는_영화관_리스트를_반환한다(
+        Credentials credentials,
+        List<TheaterRequest> theaterRequests,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        for (TheaterRequest theaterRequest : theaterRequests) {
+            createTheater(client, accessToken, theaterRequest);
+        }
+
+        // Act
+        TheaterRequest theaterToFind = theaterRequests.get(1);
+        ResponseEntity<PageResponse<TheaterResponse>> response = getWithToken(client,
+            accessToken,
+            "/theaters?pageNumber=0&pageSize=" + theaterRequests.size() + "&address=" + theaterToFind.address(),
+            new ParameterizedTypeReference<>() {
+            });
+
+        // Assert
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().content().size()).isEqualTo(1);
+        TheaterResponse found = response.getBody().content().get(0);
+        assertThat(found.name()).isEqualTo(theaterToFind.name());
+        assertThat(found.address()).isEqualTo(theaterToFind.address());
     }
 }

--- a/src/test/java/com/kjh/ticketreserve/theater/GetTests.java
+++ b/src/test/java/com/kjh/ticketreserve/theater/GetTests.java
@@ -28,7 +28,7 @@ public class GetTests {
         // Arrange
         signup(client, credentials);
         String accessToken = signin(client, credentials);
-        long id = createTheater(theaterRequest, client, accessToken);
+        long id = createTheater(client, accessToken, theaterRequest);
 
         // Act
         ResponseEntity<TheaterResponse> response = getWithToken(client,

--- a/src/test/java/com/kjh/ticketreserve/theater/GetTests.java
+++ b/src/test/java/com/kjh/ticketreserve/theater/GetTests.java
@@ -1,0 +1,47 @@
+package com.kjh.ticketreserve.theater;
+
+import com.kjh.ticketreserve.AutoDomainSource;
+import com.kjh.ticketreserve.Credentials;
+import com.kjh.ticketreserve.TheaterRequest;
+import com.kjh.ticketreserve.TheaterResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.ResponseEntity;
+
+import static com.kjh.ticketreserve.TestLanguage.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("GET /theaters")
+public class GetTests {
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 영화관_아이디를_사용해_조회하면_영화관_정보를_반환한다(
+        Credentials credentials,
+        TheaterRequest theaterRequest,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        long id = createTheater(theaterRequest, client, accessToken);
+
+        // Act
+        ResponseEntity<TheaterResponse> response = getWithToken(client,
+            accessToken,
+            "/theaters/" + id,
+            TheaterResponse.class);
+
+        // Assert
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        TheaterResponse body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.id()).isEqualTo(id);
+        assertThat(body.name()).isEqualTo(theaterRequest.name());
+        assertThat(body.address()).isEqualTo(theaterRequest.address());
+    }
+}

--- a/src/test/java/com/kjh/ticketreserve/theater/PostTests.java
+++ b/src/test/java/com/kjh/ticketreserve/theater/PostTests.java
@@ -1,0 +1,45 @@
+package com.kjh.ticketreserve.theater;
+
+import com.kjh.ticketreserve.AutoDomainSource;
+import com.kjh.ticketreserve.Credentials;
+import com.kjh.ticketreserve.TheaterRequest;
+import com.kjh.ticketreserve.TheaterResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.ResponseEntity;
+
+import static com.kjh.ticketreserve.TestLanguage.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("POST /admin/theaters")
+public class PostTests {
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 영화관을_등록하면_아이디를_반환한다(
+        Credentials credentials,
+        TheaterRequest theaterRequest,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+
+        // Act
+        ResponseEntity<TheaterResponse> response = postWithToken(client,
+            accessToken,
+            "/admin/theaters",
+            theaterRequest,
+            new ParameterizedTypeReference<>() {
+            });
+
+        // Assert
+        assertThat(response.getStatusCode().value()).isEqualTo(201);
+        assertThat(response.getBody()).hasFieldOrProperty("id");
+    }
+}

--- a/src/test/java/com/kjh/ticketreserve/theater/PutTests.java
+++ b/src/test/java/com/kjh/ticketreserve/theater/PutTests.java
@@ -1,0 +1,72 @@
+package com.kjh.ticketreserve.theater;
+
+import com.kjh.ticketreserve.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.ResponseEntity;
+
+import static com.kjh.ticketreserve.TestLanguage.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DisplayName("PUT /admin/theaters")
+public class PutTests {
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 영화관_아이디를_사용해_영화관_정보를_수정하면_수정된_정보를_반환한다(
+        Credentials credentials,
+        TheaterRequest createTheaterRequest,
+        TheaterRequest updateTheaterRequest,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+        long id = createTheater(client, accessToken, createTheaterRequest);
+
+        // Act
+        ResponseEntity<TheaterResponse> response = putWithToken(client,
+            accessToken,
+            "/admin/theaters/" + id,
+            updateTheaterRequest,
+            new ParameterizedTypeReference<>() {
+            });
+
+        // Assert
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        TheaterResponse body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.id()).isEqualTo(id);
+        assertThat(body.name()).isEqualTo(updateTheaterRequest.name());
+        assertThat(body.address()).isEqualTo(updateTheaterRequest.address());
+    }
+
+    @ParameterizedTest
+    @AutoDomainSource
+    void 존재하지_않는_영화관_아이디를_사용해_수정하면_Not_Found_상태코드를_반환한다(
+        Credentials credentials,
+        long id,
+        TheaterRequest theaterRequest,
+        @Autowired TestRestTemplate client
+    ) {
+        // Arrange
+        signup(client, credentials);
+        String accessToken = signin(client, credentials);
+
+        // Act
+        ResponseEntity<TheaterResponse> response = putWithToken(client,
+            accessToken,
+            "/admin/theaters/" + id,
+            theaterRequest,
+            new ParameterizedTypeReference<>() {
+            });
+
+        // Asssert
+        assertThat(response.getStatusCode().value()).isEqualTo(404);
+    }
+}


### PR DESCRIPTION
#12, #13, #14, #15 이슈에 대한 작업 내용입니다.

- 상영시간표 등록
  - POST `/admin/showtimes` 
  - Body : {“movieId”: {movieId}, “theaterId”: {theaterId}, “showtime”: {showtime}}
- 상영시간표 수정
  - PUT `/admin/showtimes/{id}`
  - Body : {“showtime”: {showtime}}
- 상영시간표 삭제
  - DELETE `/admin/showtimes/{id}`
- 아이디를 사용한 상영시간표 단건 조회
  - GET `/showtimes/{id}`
- 검색 조건을 사용한 상영시간표 목록 조회
  - GET `/showtimes?pageNumber={pageNumber}&pageSize={pageSize}&movieId={movieId}&theaterId={theaterId}&date={date}`
  - 검색조건
    - movieId(영화 아이디): 해당 영화로 상영중인 시간표 조회
    - theaterId(영화관 아이디): 해당 영화관에서 상영중인 시간표 조회
    - date(일자): 해당 일자에 상영중인 시간표 조회