### PR TITLE
상영시간표의 좌석 조회 기능 추가

### DIFF
--- a/src/main/java/com/kjh/ticketreserve/ReservationStatus.java
+++ b/src/main/java/com/kjh/ticketreserve/ReservationStatus.java
@@ -1,0 +1,6 @@
+package com.kjh.ticketreserve;
+
+public enum ReservationStatus {
+    RESERVED,
+    CANCELED
+}

--- a/src/main/java/com/kjh/ticketreserve/ShowtimeSeat.java
+++ b/src/main/java/com/kjh/ticketreserve/ShowtimeSeat.java
@@ -1,0 +1,11 @@
+package com.kjh.ticketreserve;
+
+public record ShowtimeSeat(long id, SeatRowCode rowCode, int number, ShowtimeSeatStatus status) {
+
+    public ShowtimeSeat(long id, SeatRowCode rowCode, int number, ReservationStatus status) {
+        this(id,
+            rowCode,
+            number,
+            ReservationStatus.RESERVED.equals(status) ? ShowtimeSeatStatus.RESERVED : ShowtimeSeatStatus.AVAILABLE);
+    }
+}

--- a/src/main/java/com/kjh/ticketreserve/ShowtimeSeatResponse.java
+++ b/src/main/java/com/kjh/ticketreserve/ShowtimeSeatResponse.java
@@ -1,0 +1,4 @@
+package com.kjh.ticketreserve;
+
+public record ShowtimeSeatResponse(long id, SeatRowCode rowCode, int number, ShowtimeSeatStatus status) {
+}

--- a/src/main/java/com/kjh/ticketreserve/ShowtimeSeatStatus.java
+++ b/src/main/java/com/kjh/ticketreserve/ShowtimeSeatStatus.java
@@ -1,0 +1,6 @@
+package com.kjh.ticketreserve;
+
+public enum ShowtimeSeatStatus {
+    AVAILABLE,
+    RESERVED
+}

--- a/src/main/java/com/kjh/ticketreserve/controller/ShowtimeController.java
+++ b/src/main/java/com/kjh/ticketreserve/controller/ShowtimeController.java
@@ -12,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @RestController
 public class ShowtimeController {
@@ -85,5 +86,12 @@ public class ShowtimeController {
                 new MovieResponse(s.getMovie()),
                 new TheaterResponse(s.getTheater()),
                 s.getShowDatetime())));
+    }
+
+    @GetMapping("/showtimes/{id}/seats")
+    public ResponseEntity<ArrayResponse<ShowtimeSeatResponse>> getSeats(@PathVariable long id) {
+        List<ShowtimeSeat> showtimeSeats = showtimeService.getSeats(id);
+        return ResponseEntity.status(200).body(new ArrayResponse<>(showtimeSeats,
+            s -> new ShowtimeSeatResponse(s.id(), s.rowCode(), s.number(), s.status())));
     }
 }

--- a/src/main/java/com/kjh/ticketreserve/jpa/SeatCustomRepository.java
+++ b/src/main/java/com/kjh/ticketreserve/jpa/SeatCustomRepository.java
@@ -1,0 +1,10 @@
+package com.kjh.ticketreserve.jpa;
+
+import com.kjh.ticketreserve.ShowtimeSeat;
+
+import java.util.List;
+
+public interface SeatCustomRepository {
+
+    List<ShowtimeSeat> findShowtimeSeats(Long theaterId, Long showtimeId);
+}

--- a/src/main/java/com/kjh/ticketreserve/jpa/SeatCustomRepositoryImpl.java
+++ b/src/main/java/com/kjh/ticketreserve/jpa/SeatCustomRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.kjh.ticketreserve.jpa;
+
+import com.kjh.ticketreserve.ReservationStatus;
+import com.kjh.ticketreserve.ShowtimeSeat;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.kjh.ticketreserve.model.QReservation.reservation;
+import static com.kjh.ticketreserve.model.QSeat.seat;
+
+@RequiredArgsConstructor
+public class SeatCustomRepositoryImpl implements SeatCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<ShowtimeSeat> findShowtimeSeats(Long theaterId, Long showtimeId) {
+        return queryFactory
+            .select(Projections.constructor(ShowtimeSeat.class,
+                seat.id,
+                seat.rowCode,
+                seat.number,
+                reservation.status
+            ))
+            .from(seat)
+            .leftJoin(reservation)
+            .on(
+                seat.id.eq(reservation.seat.id)
+                    .and(reservation.showtime.id.eq(showtimeId))
+                    .and(reservation.status.eq(ReservationStatus.RESERVED))
+            )
+            .where(
+                seat.theater.id.eq(theaterId)
+            )
+            .fetch();
+    }
+}

--- a/src/main/java/com/kjh/ticketreserve/jpa/SeatRepository.java
+++ b/src/main/java/com/kjh/ticketreserve/jpa/SeatRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface SeatRepository extends JpaRepository<Seat, Long> {
+public interface SeatRepository extends JpaRepository<Seat, Long>, SeatCustomRepository {
 
     boolean existsByTheaterIdAndRowCodeAndNumber(Long theaterId, SeatRowCode rowCode, int number);
 

--- a/src/main/java/com/kjh/ticketreserve/model/Reservation.java
+++ b/src/main/java/com/kjh/ticketreserve/model/Reservation.java
@@ -1,0 +1,35 @@
+package com.kjh.ticketreserve.model;
+
+import com.kjh.ticketreserve.ReservationStatus;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class Reservation {
+
+    @Id
+    @GeneratedValue
+    Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "showtime_id", nullable = false)
+    private Showtime showtime;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seat_id", nullable = false)
+    private Seat seat;
+
+    private Integer price;
+
+    @Enumerated(EnumType.STRING)
+    private ReservationStatus status;
+}

--- a/src/main/java/com/kjh/ticketreserve/service/ShowtimeService.java
+++ b/src/main/java/com/kjh/ticketreserve/service/ShowtimeService.java
@@ -1,25 +1,33 @@
 package com.kjh.ticketreserve.service;
 
 import com.kjh.ticketreserve.ShowtimeSearchCondition;
+import com.kjh.ticketreserve.ShowtimeSeat;
 import com.kjh.ticketreserve.ShowtimeUpdateRequest;
 import com.kjh.ticketreserve.exception.BadRequestException;
 import com.kjh.ticketreserve.exception.NotFoundException;
+import com.kjh.ticketreserve.jpa.SeatRepository;
 import com.kjh.ticketreserve.jpa.ShowtimeRepository;
 import com.kjh.ticketreserve.model.Showtime;
+import com.kjh.ticketreserve.model.Theater;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Service
 public class ShowtimeService {
 
     private final ShowtimeRepository showtimeRepository;
+    private final SeatRepository seatRepository;
+    private final TheaterService theaterService;
 
-    public ShowtimeService(ShowtimeRepository showtimeRepository) {
+    public ShowtimeService(ShowtimeRepository showtimeRepository, SeatRepository seatRepository, TheaterService theaterService) {
         this.showtimeRepository = showtimeRepository;
+        this.seatRepository = seatRepository;
+        this.theaterService = theaterService;
     }
 
     @Transactional
@@ -55,5 +63,11 @@ public class ShowtimeService {
     public Page<Showtime> searchShowtimes(int pageNumber, int pageSize, Long movieId, Long theaterId, LocalDate date) {
         ShowtimeSearchCondition searchCondition = new ShowtimeSearchCondition(movieId, theaterId, date);
         return showtimeRepository.findAllBySearchCondition(searchCondition, PageRequest.of(pageNumber, pageSize));
+    }
+
+    public List<ShowtimeSeat> getSeats(long id) {
+        Showtime showtime = showtimeRepository.findById(id).orElseThrow(NotFoundException.NOT_FOUND_SHOWTIME);
+        Theater theater = theaterService.getTheater(showtime.getTheater().getId());
+        return seatRepository.findShowtimeSeats(theater.getId(), showtime.getId());
     }
 }

--- a/src/test/java/com/kjh/ticketreserve/showtime/GetTests.java
+++ b/src/test/java/com/kjh/ticketreserve/showtime/GetTests.java
@@ -247,6 +247,6 @@ public class GetTests {
             .allMatch(seatResponse -> seatRequests.stream()
                 .anyMatch(seatRequest -> seatRequest.rowCode() == seatResponse.rowCode()
                     && seatRequest.number() == seatResponse.number()));
-        assertThat(hasSameSeats).isEqualTo(true);
+        assertThat(hasSameSeats).isTrue();
     }
 }


### PR DESCRIPTION
- 특정 상영시간표의 좌석 조회
  - GET `/showtimes/{showtimeId}/seats`
  - 좌석 정보에는 예매 가능 상태를 포함한다. RESERVED(예매 불가), AVAILABLE(예매 가능)

Resolves #24